### PR TITLE
idmocp-25: on-demand developer image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
 stages:
 - sanity
 - build
+- tests
 
 matrix:
   include:
@@ -47,6 +48,10 @@ matrix:
       env: dockerfile=centos-7
     - stage: build
       env: dockerfile=fedora-23 replica=none seccomp=unconfined readonly=--read-only
+    - stage: tests
+      script:
+      - docker run --rm -it quay.io/buildah/stable buildah version
+      - ./tests/test-build-and-push-image.sh
   exclude:
     - stage: build
       env: dockerfile=rhel-7

--- a/README
+++ b/README
@@ -237,6 +237,29 @@ To check the general health of the project, you can check
 https://travis-ci.org/freeipa/freeipa-container/ where tests are run
 for various OSes (in the container).
 
+# Build and Push image helper script
+
+A script to help on building and pushing the image has been created,
+which can be used from the command line or in a pipeline. It offers a
+default pattern to push the images (development images), and flexibility
+to override the values using environment variables.
+
+Usage:
+
+```shell
+./devel/build-and-push-image.sh
+```
+
+The environment variables available are:
+- **BAPI_DOCKERFILE**: Indicate the Dockerfile to be used; by default it is
+  'Dockerfile'.
+- **BAPI_REMOTE_IMAGE**: The reference to the remote image, indicating the image
+  registry.
+- **BAPI_LOCAL_TAG**: Local reference to be used for the image.
+- **BAPI_USERNAME**: The username to login in the remote image registry.
+- **BAPI_PASSWORD**: The password to login in the remote image registry.
+
+
 # License
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/devel/build-and-push-image.sh
+++ b/devel/build-and-push-image.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+##
+# This script is ready to be used inside the container image:
+#   quay.io/buildah/stable
+# with no provileges.
+#
+# Environment variables used by the script:
+#   BAPI_DOCKERFILE    Indicate the Dockerfile to be used; by default it is 'Dockerfile'.
+#   BAPI_REMOTE_IMAGE  The reference to the remote image, indicating the image registry.
+#   BAPI_LOCAL_TAG     Local reference to be used for the image.
+#   BAPI_USERNAME      The username to login in the remote image registry.
+#   BAPI_PASSWORD      The password to login in the remote image registry.
+##
+
+
+function verbose
+{
+    echo "$@"; "$@"
+}
+
+
+function yield
+{
+    echo "$*" >&2
+}
+
+
+function error-msg
+{
+    yield "ERROR:$*"
+}
+
+
+function die
+{
+    local err=$?
+    [ $err -eq 0 ] && err=127
+    error-msg "$@"
+    exit $err
+}
+
+
+function print-repo-hash
+{
+    if command -v git 2>/dev/null 1>/dev/null
+    then
+        git rev-parse --short HEAD && return 0
+    fi
+
+    # From Travis CI
+    # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+    if [ "${TRAVIS_PULL_REQUEST_SHA}" != "" ]
+    then
+        printf "%s\n" "${TRAVIS_PULL_REQUEST_SHA:0:7}" && return 0
+        return $?
+    fi
+
+    # From GitHub CI
+    # https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+    if [ "${GITHUB_SHA}" != "" ]
+    then
+        printf "%s\n" "${GITHUB_SHA:0:7}" && return 0
+        return $?
+    fi
+
+    # From GitLab CI
+    # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    if [ "${CI_COMMIT_SHA}" != "" ]
+    then
+        printf "%s\n" "${CI_COMMIT_SHA:0:7}" && return 0
+        return $?
+    fi
+
+    printf "%s\n" "xxxxxxx" && return 127
+    return $?
+}
+
+
+set -o pipefail
+[ "${BAPI_USERNAME}" != "" ] || die "BAPI_USERNAME variable can not be empty"
+[ "${BAPI_PASSWORD}" != "" ] || die "BAPI_PASSWORD variable can not be empty"
+if [ "$BAPI_REMOTE_IMAGE" == "" ] || [ "$BAPI_LOCAL_TAG" == "" ]
+then
+    BAPI_GIT_HASH="$( print-repo-hash )"
+fi
+BAPI_DOCKERFILE="${BAPI_DOCKERFILE:-Dockerfile}"
+BAPI_REMOTE_IMAGE="${BAPI_REMOTE_IMAGE:-docker.io/freeipa/freeipa-server:dev-${BAPI_GIT_HASH}}"
+BAPI_LOCAL_TAG="${BAPI_LOCAL_TAG:-localhost/freeipa/freeipa-server:dev-${BAPI_GIT_HASH}}"
+BAPI_TMP="$( mktemp /tmp/bapi-XXXXXX )"
+buildah --storage-driver vfs bud --isolation chroot -t "${BAPI_LOCAL_TAG}" -t "${BAPI_REMOTE_IMAGE}" -f "${BAPI_DOCKERFILE}" . | tee "${BAPI_TMP}" || exit 1
+_RETURN=$?
+BAPI_IMAGE_ID="$( tail -n 1 "${BAPI_TMP}" )"
+echo "> Pushing image to '${BAPI_REMOTE_IMAGE}'"
+[ $_RETURN -eq 0 ] && buildah --storage-driver vfs push --creds "${BAPI_USERNAME}:${BAPI_PASSWORD}" "${BAPI_IMAGE_ID}" "docker://${BAPI_REMOTE_IMAGE}"
+rm -f "${BAPI_TMP}"

--- a/tests/test-build-and-push-image.sh
+++ b/tests/test-build-and-push-image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if command -v podman 2>/dev/null 1>/dev/null
+then
+    oci="podman"
+elif command -v docker 2>/dev/null 1>/dev/null
+then
+    oci="docker"
+else
+    echo "No docker nor podman was found" >&2
+    exit 2
+fi
+
+$oci run --security-opt seccomp=unconfined \
+         --rm -it \
+         -e BAPI_USERNAME="${BAPI_USERNAME}" \
+         -e BAPI_PASSWORD="${BAPI_PASSWORD}" \
+         -e BAPI_REMOTE_IMAGE="${BAPI_REMOTE_IMAGE}" \
+         -e BAPI_DOCKERFILE="${BAPI_DOCKERFILE}" \
+         -v "$PWD:/data:z" \
+         -w "/data" \
+         quay.io/buildah/stable \
+         ./devel/build-and-push-image.sh


### PR DESCRIPTION
Helper script to build and push an image to the registry:
- It is configured with environment variables, making this container friendly.
  - **BAPI_USERNAME**: The username to access the image registry. Append it as a secret in a pipeline.
  - **BAPI_PASSWORD**: The password (or token) to access the image registry. Append it as a secret in a pipeline.
  - **BAPI_REMOTE_IMAGE**: The image tag to locate the image. It doesn't need a secret, but declare the environment variable in the pipeline.
- Append helper script for build-and-push-image.
- Append tests for the script.
- Append documentation about the usage of the script.