### PR TITLE
Add hadolint tool at 'lint' stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,23 @@ after_failure:
 - tests/run-partial-tests.sh Dockerfile.$dockerfile
 
 stages:
+- lint
 - build
 - test
 
 jobs:
   include:
+    - stage: lint
+      install: export docker=${docker:-docker}
+      script: |
+        result=0
+        for dockerfile in Dockerfile.*
+        do
+          $docker run --rm -it -v "$PWD:/data" -w "/data" hadolint/hadolint /bin/hadolint $dockerfile || result=$(( result + 1 ))
+        done
+        # exit $result
+      after_failure: skip
+
     - &build-stage
       stage: build
       env: dockerfile=fedora-32


### PR DESCRIPTION
This PR integrate **hadolint** in the pipeline, providing static analyser reports for all the Dockerfile files.

Initially this does not break the pipeline, but it is added with the idea of changing that in the future when the hints were removed.