### PR TITLE
build: add option to build from COPR repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /artifact-hash.txt
-/devel/freeipa-prci.repo
+/devel/*.repo


### PR DESCRIPTION
Enhance the check-container-build-with-prci.sh script to allow
building from a COPR repository instead of a PRCI artifact.  Use the
COPR_REPO environment variable to specify the COPR repo URL.

The target system is derived from the the repo URL.  The
copr.fedorainfracloud.org directory structure matches the system
names we use, so that's nice.  But more work may be needed to make
it work with copr.devel.redhat.com or other COPR instances.

Remove the download-repo-file-to subroutine because it was now
possible to replace it with a single curl-or-die.