### PR TITLE
build: add trailing newline when patching Dockerfile

### DIFF
--- a/devel/check-container-build-with-prci.sh
+++ b/devel/check-container-build-with-prci.sh
@@ -99,7 +99,7 @@ function patch-dockerfile
         if [[ "${line}" =~ ^FROM\ * ]]
         then
             printf "%s\n" "${line}" >> "${dockerfilepath}"
-            printf "COPY \"%s\" \"%s\"" "${repofilepath}" "/etc/yum.repos.d/freeipa-development.repo" >> "${dockerfilepath}"
+            printf "COPY \"%s\" \"%s\"\n" "${repofilepath}" "/etc/yum.repos.d/freeipa-development.repo" >> "${dockerfilepath}"
         else
             printf "%s\n" "${line}" >> "${dockerfilepath}"
         fi


### PR DESCRIPTION
When check-container-build-with-prci.sh patches the Dockerfile, it
does not append a trailing newline to the new COPY line.  If there
is an empty line following the FROM directive, this is fine.  But
otherwise, it breaks the Dockerfile.

Append a trailing newline so that adjacent lines do not get joined
by accident.