### PR TITLE
more local build improvements

### DIFF
--- a/devel/build-from-repo.sh
+++ b/devel/build-from-repo.sh
@@ -6,11 +6,11 @@
 #
 # Usage:
 #
-#   ARTIFACT_HASH="c8dbfc76-c4eb-11ea-88a6-fa163e90bd6d" ./devel/check-container-build-with-prci.sh
+#   ARTIFACT_HASH="c8dbfc76-c4eb-11ea-88a6-fa163e90bd6d" ./devel/build-from-repo.sh
 #
 #   or
 #
-#   COPR_REPO=https://.../user-project-fedora-32.repo ./devel/check-container-build-with-prci.sh
+#   COPR_REPO=https://.../user-project-fedora-32.repo ./devel/build-from-repo.sh
 ##
 
 ARTIFACT_HASH_FILENAME="artifact-hash.txt"

--- a/devel/build-from-repo.sh
+++ b/devel/build-from-repo.sh
@@ -15,6 +15,7 @@
 
 ARTIFACT_HASH_FILENAME="artifact-hash.txt"
 LATEST_FEDORA="fedora-32"
+DOCKERFILE=Dockerfile.devel
 
 function yield
 {
@@ -180,8 +181,8 @@ case "$SYSTEM" in
         die "No supported ${item}"
         ;;
 esac
-cp -f "${item}" "Dockerfile.prci"
-patch-dockerfile Dockerfile.prci "$REPO_FILE"
+cp -f "${item}" "$DOCKERFILE"
+patch-dockerfile "$DOCKERFILE" "$REPO_FILE"
 set -o pipefail
 if [ -z "$BUILDAH_DIRECT" ] ; then
     echo "Executing buildah in a container"
@@ -190,10 +191,10 @@ if [ -z "$BUILDAH_DIRECT" ] ; then
                 --volume "$PWD:/data:z" \
                 --workdir "/data" \
                 quay.io/buildah/stable \
-                buildah --storage-driver vfs bud --isolation chroot -f Dockerfile.prci .
+                buildah --storage-driver vfs bud --isolation chroot -f "$DOCKERFILE" .
 else
     echo "Executing buildah locally"
-    buildah bud --layers --isolation chroot -f Dockerfile.prci .
+    buildah bud --layers --isolation chroot -f "$DOCKERFILE" .
 fi
 
 if [ "$?" -eq 0 ]
@@ -204,4 +205,4 @@ else
     yield "ERROR:$( basename "${item}" ) failed to build"
     failured_files+=( "$( basename "${item}" )")
 fi
-rm -f Dockerfile.prci
+rm -f "$DOCKERFILE"

--- a/devel/check-container-build-with-prci.sh
+++ b/devel/check-container-build-with-prci.sh
@@ -156,6 +156,7 @@ cp -f "${item}" "Dockerfile.prci"
 patch-dockerfile Dockerfile.prci "$REPO_FILE"
 set -o pipefail
 if [ -z "$BUILDAH_DIRECT" ] ; then
+    echo "Executing buildah in a container"
     docker run --security-opt seccomp=unconfined \
                 --rm -it \
                 --volume "$PWD:/data:z" \
@@ -163,7 +164,8 @@ if [ -z "$BUILDAH_DIRECT" ] ; then
                 quay.io/buildah/stable \
                 buildah --storage-driver vfs bud --isolation chroot -f Dockerfile.prci .
 else
-    buildah --storage-driver vfs bud --layers --isolation chroot -f Dockerfile.prci .
+    echo "Executing buildah locally"
+    buildah bud --layers --isolation chroot -f Dockerfile.prci .
 fi
 
 if [ "$?" -eq 0 ]


### PR DESCRIPTION
```
604b75a (Fraser Tweedale, 9 minutes ago)
   build: separate build step for devel package install

   To speed up building during development, make the installation of packages
   from the development repo a separate build step, after the initial dnf
   upgrade/install/clean.  This saves a lot of time during build because we
   already have a cached layer with packages upgraded and FreeIPA packages
   installed.

   To avoid having a layer with package metadata present, only to be cleaned
   in a subsequent build step (a waste of space in the image), both dnf build
   steps have to download (and clean up) all the repo metadata.  This is not
   ideal as it does waste some time downloading the repo data two times, but I
   don't see a good workaround.

0312e25 (Fraser Tweedale, 2 hours ago)
   build: avoid cache invalidation due to repo file

   Build caching is aware of not only the content of files that are added to
   the image via COPY, but also the mtime.  Therefore using curl to fetch the
   repo file defeats build caching.

   To avoid spurious cache invalidation, download the repo file to a temp
   file.  Only replace the existing repo file if the content changed, or if
   user demands is via $FORCE.

de565d9 (Fraser Tweedale, 3 hours ago)
   do not override storage driver for local build

   For compatibility with podman, use the default storage driver for a local
   build.  When podman is configured to use overlay, it cannot see or prune
   vfs images, even when you specify --storage-driver=vfs:

       % podman --storage-driver=vfs image prune
      Error: database storage graph driver "overlay" does not match our
      storage graph driver "vfs": database configuration mismatch

   Because buildah does not offer a prune command, this is very annoying - the
   caches grows and grows but the tooling provides no way to prune it. 
   Therefore it is better to just use the same storage driver as podman
   (overlay).

   Also add a message that prints whether the script is invoking buildah
   locally or in a container.
```