### PR TITLE
Add nightly upstream freeipa-server container image builds

### DIFF
--- a/.github/workflows/nightly-upstream.yaml
+++ b/.github/workflows/nightly-upstream.yaml
@@ -1,0 +1,83 @@
+name: Build nightly upstream
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * *'
+
+env:
+  TRAVIS: yes-similar-ubuntu-environment
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+    env:
+      COPR_REPO: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/${{ matrix.os }}/group_freeipa-freeipa-master-nightly-${{ matrix.os }}.repo
+      QUAY_EXPIRATION: 2w
+      IMAGE_TAG_BASE: local/freeipa-server:nightly-upstream-
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: ./devel/build-from-repo.sh
+      - name: File issue if building image failed
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        run: |
+          curl -s 'https://api.github.com/repos/${{ github.repository }}/issues?labels=image-build-fail' | jq -r '.[0].state' | grep open \
+          || curl -s -X POST \
+            --url https://api.github.com/repos/${{ github.repository }}/issues \
+            -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3+json' \
+            -d '{
+              "title": "Nightly upstream image build for ${{ matrix.os }} failed on '$( date -I )'",
+              "body": "This issue was automatically created by GitHub Action\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.\n",
+              "labels": ["image-build-fail" ]
+              }'
+      - name: Create directory for artifacts
+        run: mkdir nightly-upstream-freeipa-server-${{ matrix.os }}
+      - name: Save image
+        run: docker save ${IMAGE_TAG_BASE}${{ matrix.os }} | gzip > nightly-upstream-freeipa-server-${{ matrix.os }}/nightly-upstream-freeipa-server-${{ matrix.os }}.tar.gz
+      - name: Get FreeIPA version
+        run: docker run --rm --entrypoint rpm ${IMAGE_TAG_BASE}${{ matrix.os }} -qf --qf '%{version}\n' /usr/sbin/ipa-server-install > nightly-upstream-freeipa-server-${{ matrix.os }}/nightly-upstream-freeipa-server-${{ matrix.os }}.version
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nightly-upstream-freeipa-server-${{ matrix.os }}
+          path: nightly-upstream-freeipa-server-${{ matrix.os }}
+
+  push-after-success:
+    name: Push images to nightly registries
+    runs-on: ubuntu-20.04
+    needs: [ build ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/openshift-4.x'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: nightly-upstream-freeipa-server-${{ matrix.os }}
+      - name: Prepare authentication file
+        run: |
+          cat > auth.json << 'EOF'
+          ${{ secrets.REGISTRY_CREDENTIALS_FILE }}
+          EOF
+      - name: Copy the images to registries
+        run: |
+          while read r ; do
+            for f in nightly-upstream-freeipa-server-*.tar.gz ; do j=${f%.tar.gz} ;
+              echo Copying $j to ${r#docker://}
+              source="docker-archive:$f"
+              target="$r:${j%-}-$( cat $j.version )"
+              target="${target%%+*}"
+              skopeo copy --authfile=auth.json "${source}" "${target}"
+              echo Tagged as ${j#nightly-upstream-freeipa-server-}-$( cat $j.version )
+            done
+          done << 'EOF'
+          ${{ secrets.REGISTRY_TARGET_LIST }}
+          EOF

--- a/.github/workflows/nightly-upstream.yaml
+++ b/.github/workflows/nightly-upstream.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+        os: [ fedora-rawhide, fedora-34, fedora-33, fedora-32, centos-8 ]
     continue-on-error: ${{ matrix.os == 'fedora-rawhide' }}
     env:
       COPR_REPO: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/${{ matrix.os }}/group_freeipa-freeipa-master-nightly-${{ matrix.os }}.repo
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+        os: [ fedora-rawhide, fedora-34, fedora-33, fedora-32, centos-8 ]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/openshift-4.x'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/nightly-upstream.yaml
+++ b/.github/workflows/nightly-upstream.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+    continue-on-error: ${{ matrix.os == 'fedora-rawhide' }}
     env:
       COPR_REPO: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/${{ matrix.os }}/group_freeipa-freeipa-master-nightly-${{ matrix.os }}.repo
       QUAY_EXPIRATION: 2w

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,32 +27,16 @@ after_failure:
 - tests/run-partial-tests.sh Dockerfile.$dockerfile
 
 stages:
-- lint
 - build
 - test
-- delivery
 
 jobs:
   include:
-    - stage: lint
-      install: export docker=${docker:-docker}
-      script: |
-        result=0
-        for dockerfile in Dockerfile.*
-        do
-          $docker run --rm -it -v "$PWD:/data" -w "/data" hadolint/hadolint /bin/hadolint $dockerfile || result=$(( result + 1 ))
-        done
-        # exit $result
-      after_failure: skip
-
     - &build-stage
       stage: build
       env: dockerfile=fedora-34
       install: export docker=${docker:-docker}
-      script: |
-        $docker build -t local/freeipa-server:$dockerfile -f Dockerfile.$dockerfile . \
-        && $docker save --output local-freeipa-server-$dockerfile.tar local/freeipa-server:$dockerfile \
-        && ( $docker run --rm --interactive --tty --volume /var/run/docker.sock:/var/run/docker.sock:z --volume "$PWD:$PWD:z" -w "$PWD" wagoodman/dive:latest --ci --ci-config .dive-ci.yml local/freeipa-server:$dockerfile || true )
+      script: $docker build -t local/freeipa-server:$dockerfile -f Dockerfile.$dockerfile . && $docker save --output local-freeipa-server-$dockerfile.tar local/freeipa-server:$dockerfile
       after_failure: skip
       workspaces:
         create:
@@ -94,43 +78,3 @@ jobs:
       workspaces:
         use: centos-8
 
-    - &delivery-image
-      stage: delivery
-      env: dockerfile=fedora-32
-      script: |
-        # https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
-        if [ "$TRAVIS_PULL_REQUEST" == "false" ]
-        then
-          $docker load -i local-freeipa-server-$dockerfile.tar
-          # https://docs.travis-ci.com/user/docker/#private-registry-login
-          echo "${DOCKER_PASSWORD}" | $docker login --username "${DOCKER_USERNAME}" --password-stdin "${IMAGE_TAG_BASE%%/*}"
-          if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_EVENT_TYPE}" != "pull_request" ];
-          then
-            export FINAL_TAG="${IMAGE_TAG_BASE}:${dockerfile}";
-          else
-            export GIT_HASH="$( git rev-parse HEAD 2>/dev/null )";
-            export FINAL_TAG="${IMAGE_TAG_BASE}:${dockerfile}-${GIT_HASH}";
-          fi
-          $docker tag local/freeipa-server:${dockerfile} ${FINAL_TAG} || exit $?
-          $docker --log-level debug push ${FINAL_TAG} 2>&1 || exit $?
-        else
-          echo "INFO: Delivering nothing for Pull Requests"
-        fi
-      workspaces:
-        use: fedora-32
-    - <<: *delivery-image
-      env: dockerfile=fedora-31
-      workspaces:
-        use: fedora-31
-    - <<: *delivery-image
-      env: dockerfile=centos-8
-      workspaces:
-        use: centos-8
-    - <<: *delivery-image
-      env: dockerfile=centos-7
-      workspaces:
-        use: centos-7
-    - <<: *delivery-image
-      env: dockerfile=fedora-23
-      workspaces:
-        use: fedora-23

--- a/devel/build-from-repo.sh
+++ b/devel/build-from-repo.sh
@@ -179,6 +179,7 @@ failured_files=()
 
 case "${SYSTEM}" in
     "fedora-rawhide" \
+    | "fedora-34" \
     | "fedora-33" \
     | "fedora-32" \
     | "fedora-31" \

--- a/devel/build-from-repo.sh
+++ b/devel/build-from-repo.sh
@@ -224,14 +224,18 @@ case "${IMAGE_BUILDER}" in
         die "${IMAGE_BUILDER} not supported"
         ;;
 esac
+STATUS=$?
 
-if [ "$?" -eq 0 ]
+rm -f "${DOCKERFILE}"
+
+if [ "$STATUS" -eq 0 ]
 then
     yield "INFO:$( basename "${item}" ) build properly"
     yield "INFO:Now you can use the '${IMAGE_TAG}' image"
     successed_files+=( "$( basename "${item}" )")
+    exit 0
 else
     yield "ERROR:$( basename "${item}" ) failed to build"
     failured_files+=( "$( basename "${item}" )")
+    exit 1
 fi
-rm -f "${DOCKERFILE}"


### PR DESCRIPTION
- The images expires in two weeks.
- It builds for fedora-rawhide, fedora-33, fedora-32 and centos-8.
- Update ./devel/build-from-repo.sh for using it into the pipeline.