### PR TITLE
Alternative to PR #17

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ fedora-rawhide, fedora-34, fedora-33, fedora-32, centos-8, centos-7 ]
+        os: [ fedora-rawhide, fedora-34, fedora-33, centos-8, centos-7 ]
     steps:
       - uses: actions/checkout@v2
       - name: Build image
@@ -68,7 +68,7 @@ jobs:
             ca: --external-ca
           - os: centos-7
             protected_regular: unset
-        os: [ fedora-32, fedora-33 ]
+        os: [ fedora-33 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -196,9 +196,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: freeipa-server-fedora-33
-      - uses: actions/download-artifact@v2
-        with:
-          name: freeipa-server-fedora-32
       - uses: actions/download-artifact@v2
         with:
           name: freeipa-server-centos-8

--- a/.github/workflows/nightly-upstream.yaml
+++ b/.github/workflows/nightly-upstream.yaml
@@ -1,0 +1,83 @@
+name: Build nightly upstream
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * *'
+
+env:
+  TRAVIS: yes-similar-ubuntu-environment
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+    env:
+      COPR_REPO: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/${{ matrix.os }}/group_freeipa-freeipa-master-nightly-${{ matrix.os }}.repo
+      QUAY_EXPIRATION: 2w
+      IMAGE_TAG_BASE: local/freeipa-server:nightly-upstream-
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: ./devel/build-from-repo.sh
+      - name: File issue if building image failed
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        run: |
+          curl -s 'https://api.github.com/repos/${{ github.repository }}/issues?labels=image-build-fail' | jq -r '.[0].state' | grep open \
+          || curl -s -X POST \
+            --url https://api.github.com/repos/${{ github.repository }}/issues \
+            -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3+json' \
+            -d '{
+              "title": "Nightly upstream image build for ${{ matrix.os }} failed on '$( date -I )'",
+              "body": "This issue was automatically created by GitHub Action\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.\n",
+              "labels": ["image-build-fail" ]
+              }'
+      - name: Create directory for artifacts
+        run: mkdir nightly-upstream-freeipa-server-${{ matrix.os }}
+      - name: Save image
+        run: docker save ${IMAGE_TAG_BASE}${{ matrix.os }} | gzip > nightly-upstream-freeipa-server-${{ matrix.os }}/nightly-upstream-freeipa-server-${{ matrix.os }}.tar.gz
+      - name: Get FreeIPA version
+        run: docker run --rm --entrypoint rpm ${IMAGE_TAG_BASE}${{ matrix.os }} -qf --qf '%{version}\n' /usr/sbin/ipa-server-install > nightly-upstream-freeipa-server-${{ matrix.os }}/nightly-upstream-freeipa-server-${{ matrix.os }}.version
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nightly-upstream-freeipa-server-${{ matrix.os }}
+          path: nightly-upstream-freeipa-server-${{ matrix.os }}
+
+  push-after-success:
+    name: Push images to nightly registries
+    runs-on: ubuntu-20.04
+    needs: [ build ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/openshift-4.x'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: nightly-upstream-freeipa-server-${{ matrix.os }}
+      - name: Prepare authentication file
+        run: |
+          cat > auth.json << 'EOF'
+          ${{ secrets.REGISTRY_CREDENTIALS_FILE }}
+          EOF
+      - name: Copy the images to registries
+        run: |
+          while read r ; do
+            for f in nightly-upstream-freeipa-server-*.tar.gz ; do j=${f%.tar.gz} ;
+              echo Copying $j to ${r#docker://}
+              source="docker-archive:$f"
+              target="$r:${j%-}-$( cat $j.version )"
+              target="${target%%+*}"
+              skopeo copy --authfile=auth.json "${source}" "${target}"
+              echo Tagged as ${j#nightly-upstream-freeipa-server-}-$( cat $j.version )
+            done
+          done << 'EOF'
+          ${{ secrets.REGISTRY_TARGET_LIST }}
+          EOF

--- a/.github/workflows/nightly-upstream.yaml
+++ b/.github/workflows/nightly-upstream.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+        os: [ fedora-rawhide, fedora-34, fedora-33, fedora-32, centos-8 ]
     continue-on-error: ${{ matrix.os == 'fedora-rawhide' }}
     env:
       COPR_REPO: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/${{ matrix.os }}/group_freeipa-freeipa-master-nightly-${{ matrix.os }}.repo
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+        os: [ fedora-rawhide, fedora-34, fedora-33, fedora-32, centos-8 ]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/openshift-4.x'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/nightly-upstream.yaml
+++ b/.github/workflows/nightly-upstream.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ fedora-rawhide, fedora-33, fedora-32, centos-8 ]
+    continue-on-error: ${{ matrix.os == 'fedora-rawhide' }}
     env:
       COPR_REPO: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/${{ matrix.os }}/group_freeipa-freeipa-master-nightly-${{ matrix.os }}.repo
       QUAY_EXPIRATION: 2w

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,32 +27,16 @@ after_failure:
 - tests/run-partial-tests.sh Dockerfile.$dockerfile
 
 stages:
-- lint
 - build
 - test
-- delivery
 
 jobs:
   include:
-    - stage: lint
-      install: export docker=${docker:-docker}
-      script: |
-        result=0
-        for dockerfile in Dockerfile.*
-        do
-          $docker run --rm -it -v "$PWD:/data" -w "/data" hadolint/hadolint /bin/hadolint $dockerfile || result=$(( result + 1 ))
-        done
-        # exit $result
-      after_failure: skip
-
     - &build-stage
       stage: build
       env: dockerfile=fedora-34
       install: export docker=${docker:-docker}
-      script: |
-        $docker build -t local/freeipa-server:$dockerfile -f Dockerfile.$dockerfile . \
-        && $docker save --output local-freeipa-server-$dockerfile.tar local/freeipa-server:$dockerfile \
-        && ( $docker run --rm --interactive --tty --volume /var/run/docker.sock:/var/run/docker.sock:z --volume "$PWD:$PWD:z" -w "$PWD" wagoodman/dive:latest --ci --ci-config .dive-ci.yml local/freeipa-server:$dockerfile || true )
+      script: $docker build -t local/freeipa-server:$dockerfile -f Dockerfile.$dockerfile . && $docker save --output local-freeipa-server-$dockerfile.tar local/freeipa-server:$dockerfile
       after_failure: skip
       workspaces:
         create:
@@ -91,43 +75,3 @@ jobs:
       workspaces:
         use: centos-8
 
-    - &delivery-image
-      stage: delivery
-      env: dockerfile=fedora-32
-      script: |
-        # https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
-        if [ "$TRAVIS_PULL_REQUEST" == "false" ]
-        then
-          $docker load -i local-freeipa-server-$dockerfile.tar
-          # https://docs.travis-ci.com/user/docker/#private-registry-login
-          echo "${DOCKER_PASSWORD}" | $docker login --username "${DOCKER_USERNAME}" --password-stdin "${IMAGE_TAG_BASE%%/*}"
-          if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_EVENT_TYPE}" != "pull_request" ];
-          then
-            export FINAL_TAG="${IMAGE_TAG_BASE}:${dockerfile}";
-          else
-            export GIT_HASH="$( git rev-parse HEAD 2>/dev/null )";
-            export FINAL_TAG="${IMAGE_TAG_BASE}:${dockerfile}-${GIT_HASH}";
-          fi
-          $docker tag local/freeipa-server:${dockerfile} ${FINAL_TAG} || exit $?
-          $docker --log-level debug push ${FINAL_TAG} 2>&1 || exit $?
-        else
-          echo "INFO: Delivering nothing for Pull Requests"
-        fi
-      workspaces:
-        use: fedora-32
-    - <<: *delivery-image
-      env: dockerfile=fedora-31
-      workspaces:
-        use: fedora-31
-    - <<: *delivery-image
-      env: dockerfile=centos-8
-      workspaces:
-        use: centos-8
-    - <<: *delivery-image
-      env: dockerfile=centos-7
-      workspaces:
-        use: centos-7
-    - <<: *delivery-image
-      env: dockerfile=fedora-23
-      workspaces:
-        use: fedora-23

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile.fedora-33
+Dockerfile.fedora-34

--- a/Dockerfile.centos-8
+++ b/Dockerfile.centos-8
@@ -56,6 +56,8 @@ RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-rhel-8.patch | te
 # Move configuration and data to data volume
 COPY patches/ipa-data-rhel-8.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-rhel-8.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs /usr/libexec/platform-python -m compileall
+COPY ipaplatform-rhel.conf /usr/lib/systemd/system.conf.d/ipaplatform-override.conf
+ENV IPAPLATFORM_OVERRIDE=rhel_container
 
 COPY journald-storage.conf /usr/lib/systemd/journald.conf.d/storage.conf
 

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -59,8 +59,8 @@ COPY utils/prepare-volume-template utils/populate-volume-from-template utils/ext
 RUN /usr/local/bin/extract-rpm-upgrade-scriptlets
 
 # Move configuration and data to data volume
-COPY patches/ipa-data-fedora-34.patch /root
-RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-fedora-34.patch | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
+COPY patches/ipa-data-fedora-35.patch /root
+RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-fedora-35.patch | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 COPY ipaplatform-fedora.conf /usr/lib/systemd/system.conf.d/ipaplatform-override.conf
 ENV IPAPLATFORM_OVERRIDE=fedora_container
 

--- a/Dockerfile.rhel-8
+++ b/Dockerfile.rhel-8
@@ -53,6 +53,8 @@ RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-rhel-8.patch | te
 # Move configuration and data to data volume
 COPY patches/ipa-data-rhel-8.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-rhel-8.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs /usr/libexec/platform-python -m compileall
+COPY ipaplatform-rhel.conf /usr/lib/systemd/system.conf.d/ipaplatform-override.conf
+ENV IPAPLATFORM_OVERRIDE=rhel_container
 
 COPY journald-storage.conf /usr/lib/systemd/journald.conf.d/storage.conf
 

--- a/devel/build-from-repo.sh
+++ b/devel/build-from-repo.sh
@@ -179,6 +179,7 @@ failured_files=()
 
 case "${SYSTEM}" in
     "fedora-rawhide" \
+    | "fedora-34" \
     | "fedora-33" \
     | "fedora-32" \
     | "fedora-31" \

--- a/devel/build-from-repo.sh
+++ b/devel/build-from-repo.sh
@@ -224,14 +224,18 @@ case "${IMAGE_BUILDER}" in
         die "${IMAGE_BUILDER} not supported"
         ;;
 esac
+STATUS=$?
 
-if [ "$?" -eq 0 ]
+rm -f "${DOCKERFILE}"
+
+if [ "$STATUS" -eq 0 ]
 then
     yield "INFO:$( basename "${item}" ) build properly"
     yield "INFO:Now you can use the '${IMAGE_TAG}' image"
     successed_files+=( "$( basename "${item}" )")
+    exit 0
 else
     yield "ERROR:$( basename "${item}" ) failed to build"
     failured_files+=( "$( basename "${item}" )")
+    exit 1
 fi
-rm -f "${DOCKERFILE}"

--- a/patches/ipa-data-fedora-35.patch
+++ b/patches/ipa-data-fedora-35.patch
@@ -1,0 +1,82 @@
+--- /usr/lib/python3.10/site-packages/ipaplatform/base/paths.py	2020-11-17 17:41:25.000000000 +0000
++++ /usr/lib/python3.10/site-packages/ipaplatform/base/paths.py	2020-11-20 09:49:31.065787804 +0000
+@@ -345,7 +345,7 @@
+     VAR_LOG_AUDIT = "/var/log/audit/audit.log"
+     VAR_LOG_HTTPD_DIR = "/var/log/httpd"
+     VAR_LOG_HTTPD_ERROR = "/var/log/httpd/error_log"
+-    IPABACKUP_LOG = "/var/log/ipabackup.log"
++    IPABACKUP_LOG = "/data/var/log/ipabackup.log"
+     IPACLIENT_INSTALL_LOG = "/var/log/ipaclient-install.log"
+     IPACLIENT_UNINSTALL_LOG = "/var/log/ipaclient-uninstall.log"
+     IPACLIENTSAMBA_INSTALL_LOG = "/var/log/ipaclientsamba-install.log"
+@@ -353,7 +353,7 @@
+     IPAREPLICA_CA_INSTALL_LOG = "/var/log/ipareplica-ca-install.log"
+     IPAREPLICA_CONNCHECK_LOG = "/var/log/ipareplica-conncheck.log"
+     IPAREPLICA_INSTALL_LOG = "/var/log/ipareplica-install.log"
+-    IPARESTORE_LOG = "/var/log/iparestore.log"
++    IPARESTORE_LOG = "/data/var/log/iparestore.log"
+     IPASERVER_INSTALL_LOG = "/var/log/ipaserver-install.log"
+     IPASERVER_ADTRUST_INSTALL_LOG = "/var/log/ipaserver-adtrust-install.log"
+     IPASERVER_DNS_INSTALL_LOG = "/var/log/ipaserver-dns-install.log"
+--- /usr/lib/tmpfiles.d/var.conf	2018-10-29 00:59:14.000000000 +0000
++++ /usr/lib/tmpfiles.d/var.conf	2018-12-14 10:37:58.607898037 +0000
+@@ -12,9 +12,9 @@
+ L /var/run - - - - ../run
+ 
+ d /var/log 0755 - - -
+-f /var/log/wtmp 0664 root utmp -
+-f /var/log/btmp 0660 root utmp -
+-f /var/log/lastlog 0664 root utmp -
++L /var/log/wtmp - - - - /data/var/log/wtmp
++L /var/log/btmp - - - - /data/var/log/btmp
++L /var/log/lastlog - - - - /data/var/log/lastlog
+ 
+ d /var/cache 0755 - - -
+
+#
+# Workaround https://github.com/freeipa/freeipa-container/issues/313
+#
+--- /usr/lib64/python3.10/shutil.py	2019-12-18 18:48:49.000000000 +0000
++++ /usr/lib64/python3.10/shutil.py	2020-03-11 16:17:24.727098610 +0000
+@@ -160,6 +160,8 @@
+                 raise
+             return
+         for name in names:
++            if name == 'security.selinux':
++                continue
+             try:
+                 value = os.getxattr(src, name, follow_symlinks=follow_symlinks)
+                 os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
+#
+# rndc-confgen does not seem to write through the
+# /etc/rndc.key -> /data/etc/rndc.key symlink
+#
+--- /usr/libexec/generate-rndc-key.sh	2021-01-22 19:46:55.000000000 +0000
++++ /usr/libexec/generate-rndc-key.sh	2021-01-25 08:00:24.598827718 +0000
+@@ -15,18 +15,18 @@
+
+ # This script generates /etc/rndc.key if doesn't exist AND if there is no rndc.conf
+
+-if [ ! -s /etc/rndc.key -a ! -s /etc/rndc.conf ]; then
+-  echo -n $"Generating /etc/rndc.key:"
+-  if /usr/sbin/rndc-confgen -a -A hmac-sha256 > /dev/null 2>&1
++if [ ! -s /data/etc/rndc.key -a ! -s /etc/rndc.conf ]; then
++  echo -n $"Generating /data/etc/rndc.key:"
++  if /usr/sbin/rndc-confgen -c /data/etc/rndc.key -a -A hmac-sha256 > /dev/null 2>&1
+   then
+-    chmod 640 /etc/rndc.key
+-    chown root:named /etc/rndc.key
+-    [ -x /sbin/restorecon ] && /sbin/restorecon /etc/rndc.key
+-    success $"/etc/rndc.key generation"
++    chmod 640 /data/etc/rndc.key
++    chown root:named /data/etc/rndc.key
++    [ -x /sbin/restorecon ] && /sbin/restorecon /data/etc/rndc.key
++    success $"/data/etc/rndc.key generation"
+     echo
+   else
+     rc=$?
+-    failure $"/etc/rndc.key generation"
++    failure $"/data/etc/rndc.key generation"
+     echo
+     exit $rc
+   fi

--- a/patches/ipa-data-rhel-8.patch
+++ b/patches/ipa-data-rhel-8.patch
@@ -1,28 +1,6 @@
---- /usr/lib/python3.6/site-packages/ipaplatform/base/paths.py	2020-06-10 19:34:40.000000000 +0000
-+++ /usr/lib/python3.6/site-packages/ipaplatform/base/paths.py	2020-11-07 15:06:24.474612767 +0000
-@@ -72,10 +72,10 @@
-     IPA_NSSDB_DIR = "/etc/ipa/nssdb"
-     IPA_NSSDB_PWDFILE_TXT = "/etc/ipa/nssdb/pwdfile.txt"
-     COMMON_KRB5_CONF_DIR = "/etc/krb5.conf.d/"
--    KRB5_CONF = "/etc/krb5.conf"
-+    KRB5_CONF = "/data/etc/krb5.conf"
-     KRB5_FREEIPA = COMMON_KRB5_CONF_DIR + "freeipa"
-     KRB5_FREEIPA_SERVER = COMMON_KRB5_CONF_DIR + "freeipa-server"
--    KRB5_KEYTAB = "/etc/krb5.keytab"
-+    KRB5_KEYTAB = "/data/etc/krb5.keytab"
-     LDAP_CONF = "/etc/ldap.conf"
-     LIBNSS_LDAP_CONF = "/etc/libnss-ldap.conf"
-     NAMED_CONF = "/etc/named.conf"
-@@ -88,7 +88,7 @@
-         '/usr/share/ipa/bind.ipa-options-ext.conf.template'
-     )
-     NAMED_VAR_DIR = "/var/named"
--    NAMED_KEYTAB = "/etc/named.keytab"
-+    NAMED_KEYTAB = "/data/etc/named.keytab"
-     NAMED_RFC1912_ZONES = "/etc/named.rfc1912.zones"
-     NAMED_ROOT_KEY = "/etc/named.root.key"
-     NAMED_MANAGED_KEYS_DIR = "/var/named/dynamic"
-@@ -331,7 +331,7 @@
+--- /usr/lib/python3.6/site-packages/ipaplatform/base/paths.py	2021-02-15 18:43:46.000000000 +0000
++++ /usr/lib/python3.6/site-packages/ipaplatform/base/paths.py	2021-06-03 20:05:46.970733811 +0000
+@@ -350,7 +350,7 @@
      VAR_LOG_AUDIT = "/var/log/audit/audit.log"
      VAR_LOG_HTTPD_DIR = "/var/log/httpd"
      VAR_LOG_HTTPD_ERROR = "/var/log/httpd/error_log"
@@ -31,65 +9,15 @@
      IPACLIENT_INSTALL_LOG = "/var/log/ipaclient-install.log"
      IPACLIENT_UNINSTALL_LOG = "/var/log/ipaclient-uninstall.log"
      IPACLIENTSAMBA_INSTALL_LOG = "/var/log/ipaclientsamba-install.log"
-@@ -339,7 +339,7 @@
+@@ -358,7 +358,7 @@
      IPAREPLICA_CA_INSTALL_LOG = "/var/log/ipareplica-ca-install.log"
      IPAREPLICA_CONNCHECK_LOG = "/var/log/ipareplica-conncheck.log"
      IPAREPLICA_INSTALL_LOG = "/var/log/ipareplica-install.log"
 -    IPARESTORE_LOG = "/var/log/iparestore.log"
 +    IPARESTORE_LOG = "/data/var/log/iparestore.log"
      IPASERVER_INSTALL_LOG = "/var/log/ipaserver-install.log"
-     IPASERVER_KRA_INSTALL_LOG = "/var/log/ipaserver-kra-install.log"
-     IPASERVER_UNINSTALL_LOG = "/var/log/ipaserver-uninstall.log"
---- /usr/lib/python3.6/site-packages/ipaplatform/redhat/paths.py	2019-09-23 09:28:23.000000000 +0000
-+++ /usr/lib/python3.6/site-packages/ipaplatform/redhat/paths.py	2019-11-09 05:54:47.896060575 +0000
-@@ -39,7 +39,7 @@
-     AUTHCONFIG = '/usr/sbin/authconfig'
-     AUTHSELECT = '/usr/bin/authselect'
-     SYSCONF_NETWORK = '/etc/sysconfig/network'
--    NSSWITCH_CONF = '/etc/authselect/user-nsswitch.conf'
-+    NSSWITCH_CONF = '/data/etc/authselect/user-nsswitch.conf'
- 
- 
- paths = RedHatPathNamespace()
---- /usr/share/ipa/ipaca_default.ini	2019-04-25 12:35:58.000000000 +0000
-+++ /usr/share/ipa/ipaca_default.ini	2019-05-06 17:41:27.278583996 +0000
-@@ -24,7 +24,7 @@
- 
- # Dogtag defaults
- pki_instance_name=pki-tomcat
--pki_configuration_path=/etc/pki
-+pki_configuration_path=/data/etc/pki
- pki_instance_configuration_path=%(pki_configuration_path)s/%(pki_instance_name)s
- 
- pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
---- /usr/libexec/ipa/ipa-httpd-pwdreader	2018-10-05 18:30:34.000000000 +0000
-+++ /usr/libexec/ipa/ipa-httpd-pwdreader	2018-11-16 07:17:55.235711545 +0000
-@@ -13,7 +13,7 @@
- fi
- 
- fname=${1/:/-}-$2
--pwdpath=/var/lib/ipa/passwds/$fname
-+pwdpath=/data/var/lib/ipa/passwds/$fname
- 
- # Make sure the values passed in do not contain path information
- checkpath=$(/usr/bin/realpath -e ${pwdpath} 2>/dev/null)
-#
-# Prevent unneeded /etc/httpd/conf.modules.d/02-ipa-wsgi.conf from
-# being created in runtime
-#
---- /usr/lib/python3.6/site-packages/ipaplatform/fedora/paths.py.orig	2019-02-27 21:40:03.000000000 +0000
-+++ /usr/lib/python3.6/site-packages/ipaplatform/fedora/paths.py	2019-03-04 09:22:27.456146528 +0000
-@@ -30,9 +30,7 @@
- 
- 
- class FedoraPathNamespace(RedHatPathNamespace):
--    HTTPD_IPA_WSGI_MODULES_CONF = (
--        "/etc/httpd/conf.modules.d/02-ipa-wsgi.conf"
--    )
-+    HTTPD_IPA_WSGI_MODULES_CONF = None
-     NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
-     if HAS_NFS_CONF:
-         SYSCONFIG_NFS = '/etc/nfs.conf'
+     IPASERVER_ADTRUST_INSTALL_LOG = "/var/log/ipaserver-adtrust-install.log"
+     IPASERVER_DNS_INSTALL_LOG = "/var/log/ipaserver-dns-install.log"
 --- /usr/lib/tmpfiles.d/var.conf        2018-10-29 00:59:14.000000000 +0000
 +++ /usr/lib/tmpfiles.d/var.conf        2018-12-14 10:37:58.607898037 +0000
 @@ -12,9 +12,9 @@
@@ -107,32 +35,6 @@
 
 #
 # Support /var/lib/samba on /data volume
-#
---- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
-+++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
-@@ -4,6 +4,7 @@
- # you modified it.
- 
- [global]
-+	state directory = /data/var/lib/samba
- 	workgroup = SAMBA
- 	security = user
- 
---- /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
-+++ /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
-@@ -465,7 +465,9 @@
-         conf_fd.write('### Added by IPA Installer ###\n')
-         conf_fd.write('[global]\n')
-         conf_fd.write('debug pid = yes\n')
--        conf_fd.write('config backend = registry\n')
-+        conf_fd.write('state directory = /data/var/lib/samba\n')
-+        conf_fd.write('cache directory = /data/var/lib/samba\n')
-+        conf_fd.write('include = registry\n')
-         conf_fd.close()
- 
-     def __add_plugin_conf(self, name, plugin_cn, ldif_file):
-#
-# Workaround https://github.com/freeipa/freeipa-container/issues/313
 #
 --- /usr/lib64/python3.6/shutil.py	2019-12-18 18:48:49.000000000 +0000
 +++ /usr/lib64/python3.6/shutil.py	2020-03-11 16:17:24.727098610 +0000

--- a/tests/run-master-in-k3s.sh
+++ b/tests/run-master-in-k3s.sh
@@ -30,3 +30,4 @@ fi
 sudo systemctl stop systemd-resolved.service || :
 echo nameserver $( kubectl get -o=jsonpath='{.spec.clusterIP}' service freeipa-server-service ) | sudo tee /etc/resolv.conf
 curl -Lk https://$IPA_SERVER_HOSTNAME/ | grep -E 'IPA: Identity Policy Audit|Identity Management'
+echo Secret123 | kubectl exec -i pod/freeipa-server -- kinit admin


### PR DESCRIPTION
This is PR #17 plus a series of commits (mostly cherry-picks from
`freeipa-container` that fix the build or update the platforms we
build on.

Allow rawhide to fail - it is currently broken and
`freeipa-container` repo has also disabled CI for rawhide, for the
moment.

Changes:

```
39bf612 (Jan Pazdziora, 8 weeks ago)
   Fedora 34 has been released.

b115a14 (Jan Pazdziora, 8 weeks ago)
   Fedora 32 is EOL.

25cf796 (Jan Pazdziora, 8 weeks ago)
   RHEL 8.4 shipped with FreeIPA 4.9.2 and rhel_container ipaplatform.

b450b86 (Jan Pazdziora, 8 weeks ago)
   Test kinit in K3s pod.

f0cf56b (Jan Pazdziora, 5 weeks ago)
   Update Fedora rawhide patch for Python 3.10.

e8e5351 (Fraser Tweedale, 71 minutes ago)
   ci: nightly upstream: add fedora-34

87ffc55 (Fraser Tweedale, 3 hours ago)
   ci: accept failure of rawhide container build

cb1179e (Fraser Tweedale, 4 hours ago)
   devel/build-from-repo.sh: exit nonzero if build fails

   Current the script that runs the container build does not exit nonzero if
   the container build fails.  This results in confusing CI output.  Make sure
   the script exits nonzero when the build fails.

a467e73 (Alejandro Visiedo, 4 months ago)
   Add nightly upstream freeipa-server container image builds

   - The images expires in two weeks.
   - It builds for fedora-rawhide, fedora-33, fedora-32 and centos-8.
   - Update ./devel/build-from-repo.sh for using it into the pipeline.
   - Remove dive check for the container images as dive image does
    support only amd64 arch for travis CI.
   - Restored travis CI from master as lint stage is executed from
    github pipeline and delivery stage overwrite github container
    images. A multi-arch solution should be found.

   Fix container image overwrite

   Restore .travis.yml from master; lint stage is executed in github pipeline;
   delivery stage overwrite image container, so this is removed until
   multi-arch solution is found
```