### PR TITLE
Launch systemd-tmpfiles --create everytime the container is started

### DIFF
--- a/init/ocp4.inc.sh
+++ b/init/ocp4.inc.sh
@@ -110,11 +110,17 @@ function ocp4_step_process_hostname
     fi
 }
 
+function ocp4_step_systemd_tmpfiles_create
+{
+    systemd-tmpfiles --create
+}
+
 OCP4_LIST_TASKS=()
 # +ocp4:begin-list
 OCP4_LIST_TASKS+=("ocp4_step_systemd_units_set_private_tmp_off")
 OCP4_LIST_TASKS+=("ocp4_step_systemd_units_set_private_system_off")
 OCP4_LIST_TASKS+=("ocp4_step_systemd_units_set_private_devices_off")
+OCP4_LIST_TASKS+=("ocp4_step_systemd_tmpfiles_create")
 # +ocp4:end-list
 
 tasks_helper_update_step \

--- a/test/unit/ocp4.bats
+++ b/test/unit/ocp4.bats
@@ -17,13 +17,27 @@ function setup
     mock_tasks_helper_add_after 0 "container_step_volume_update" \
                                   "ocp4_step_systemd_units_set_private_tmp_off" \
                                   "ocp4_step_systemd_units_set_private_system_off" \
-                                  "ocp4_step_systemd_units_set_private_devices_off"
+                                  "ocp4_step_systemd_units_set_private_devices_off" \
+                                  "ocp4_step_systemd_tmpfiles_create"
 }
 
 function teardown
 {
     mock unstub tasks_helper_update_step tasks_helper_add_after
 }
+
+
+@test "ocp4_step_systemd_tmpfiles_create" {
+    source './init/ocp4.inc.sh'
+
+    mock stub systemd-tmpfiles
+    mock_systemd-tmpfiles 0 --create
+    run ocp4_step_systemd_tmpfiles_create
+    assert_success
+    assert_mock systemd-tmpfiles
+    mock unstub systemd-tmpfiles
+}
+
 
 @test "ocp4_step_enable_traces" {
 


### PR DESCRIPTION
This fix a situation when the pod is restarted that made dirsrv do not
start with the error message below:

```raw
Error - Problem accessing the lockfile /var/lock/dirsrv/slapd-.../lock
```

Thanks to @tiran  (https://github.com/freeipa/freeipa-operator/pull/44#issuecomment-972975907)

