### PR TITLE
Split DM and admin passwords

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ IPA_SERVER_HOSTNAME ?= $(shell $(IPA_SERVER_HOSTNAME_CMD))
 TIMESTAMP ?= $(shell date +%Y%m%d%H%M%S)
 CA_SUBJECT := CN=freeipa-$(TIMESTAMP), O=$(REALM)
 
-TESTS_LIST ?= tasks,container,ocp4
+TESTS_LIST ?= $(wildcard test/unit/*.bats)
 
 # Set the container runtime interface
 ifneq (,$(shell bash -c "command -v podman 2>/dev/null"))
@@ -219,7 +219,7 @@ test: install-test-deps test-unit test-e2e
 
 .PHONY: test-unit
 test-unit:
-	./test/libs/bats/bin/bats ./test/unit/ocp4.bats
+	./test/libs/bats/bin/bats $(TESTS_LIST)
 
 .PHONY: test-e2e
 test-e2e: .venv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
+ifneq (,$(shell ls -1 private.mk 2>/dev/null))
 include private.mk
+else
+$(info info:For a better user experience you can customize variables by adding them to the 'private.mk' file)
+endif
 
 # Read the parent image that is used for building the container image
 PARENT_IMG ?= $(shell source ci/config/env; echo $${PARENT_IMG})
@@ -32,7 +36,7 @@ ifneq (,$(shell bash -c "command -v docker 2>/dev/null"))
 DOCKER ?= docker
 else
 ifeq (,$(DOCKER))
-$(error DOCKER is not set)
+$(error No podman nor docker were found in your environment; you can override by doing 'export DOCKER=/path/to/docker/or/podman')
 endif
 endif
 endif
@@ -51,7 +55,7 @@ endif
 
 # Change IMG_BASE on your pipeline settings to point to your upstream
 ifeq (,$(IMG_BASE))
-$(error IMG_BASE is empty; export IMG_BASE=quay.io/namespace)
+$(error IMG_BASE is empty. You can do 'export IMG_BASE=quay.io/namespace' or add this variable to the 'private.mk' file; see the 'README.md' file for further information)
 endif
 IMG_TAG ?= dev-$(shell git rev-parse --short HEAD)
 IMG ?= $(IMG_BASE)/freeipa-openshift-container:$(IMG_TAG)
@@ -81,7 +85,7 @@ dump-vars:
 .PHONY: .check-docker-image-not-empty
 .check-docker-image-not-empty: .FORCE
 ifeq (,$(IMG))
-	@echo "'IMG' must be defined. Eg: 'export IMG=quay.io/myusername/freeipa-server:latest'"
+	@echo "'IMG' can not be empty. You can do 'export IMG=quay.io/scope-name/my-image:my-tag' or add the variable to the 'private.mk' file for a better user experience"
 	@exit 1
 endif
 
@@ -152,7 +156,7 @@ ci-operator:
 .PHONY: .check-cluster-domain-not-empty
 .check-cluster-domain-not-empty: .FORCE
 ifeq (,$(CLUSTER_DOMAIN))
-	@echo "'CLUSTER_DOMAIN' must be specified; Try 'CLUSTER_DOMAIN=my.cluster.domain.com make ...'"
+	@echo "'CLUSTER_DOMAIN' can not be empty; You can do 'export CLUSTER_DOMAIN=my.cluster.domain.com' or add it to the 'private.mk' file for a better user experience"
 	@exit 1
 endif
 
@@ -168,10 +172,12 @@ endif
 .PHONY: .check-not-empty-password
 .check-not-empty-password: .FORCE
 ifeq (,$(IPA_ADMIN_PASSWORD))
-	@echo "ERROR: IPA_ADMIN_PASSWORD can not be empty"; exit 2
+	@echo "ERROR: IPA_ADMIN_PASSWORD can not be empty. You can add this variable to the 'private.mk' file; see the 'README.md' file for further information"
+	@exit 2
 endif
 ifeq (,$(IPA_DM_PASSWORD))
-	@echo "ERROR: IPA_DM_PASSWORD can not be empty"; exit 2
+	@echo "ERROR: IPA_DM_PASSWORD can not be empty. You can add this variable to the 'private.mk' file; see the 'README.md' file for further information"
+	@exit 2
 endif
 
 .PHONY: .generate-secret

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the below:
 ```raw
 IPA_ADMIN_PASSWORD = Secret123
 IPA_DM_PASSWORD = DMSecret123
-IMG_BASE = quay.io/avisied0
+IMG_BASE = quay.io/scope-name
 ```
 
 > The variable `PASSWORD` still set both password when the above ones are

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the below:
 
 ```raw
 IPA_ADMIN_PASSWORD = Secret123
-IPA_DM_PASSWORD = Secret123
+IPA_DM_PASSWORD = DMSecret123
 IMG_BASE = quay.io/avisied0
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ pass information through the command line. The content could be something like
 the below:
 
 ```raw
-PASSWORD = MyAdminPassword123
+IPA_ADMIN_PASSWORD = Secret123
+IPA_DM_PASSWORD = Secret123
 IMG_BASE = quay.io/avisied0
 ```
 
-- **PASSWORD** is the admin password and directory service management password.
+> The variable `PASSWORD` still set both password when the above ones are
+> not specified; but it is recommended to use `IPA_ADMIN_PASSWORD` and
+> `IPA_DM_PASSWORD`.
+
+- **IPA_ADMIN_PASSWORD** is the administrator password.
+- **IPA_DM_PASSWORD** is the directory manager password.
 - **IMG_BASE** is the base name used to compose the container image name.
 
 Just run:

--- a/deploy/user/pod.yaml
+++ b/deploy/user/pod.yaml
@@ -160,12 +160,16 @@ spec:
             configMapKeyRef:
               name: freeipa
               key: DEBUG_TRACE
-        - name: PASSWORD
+        - name: IPA_ADMIN_PASSWORD
           valueFrom:
-            # configMapKeyRef:
             secretKeyRef:
               name: freeipa
-              key: PASSWORD
+              key: IPA_ADMIN_PASSWORD
+        - name: IPA_DM_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: freeipa
+              key: IPA_DM_PASSWORD
         - name: IPA_SERVER_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/init/ocp4.inc.sh
+++ b/init/ocp4.inc.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Directory Manager Password
+IPA_DM_PASSWORD="${IPA_DM_PASSWORD:-${PASSWORD}}"
+
+# Freeipa admin passowrd
+IPA_ADMIN_PASSWORD="${IPA_ADMIN_PASSWORD:-${PASSWORD}}"
+
 function ocp4_step_enable_traces
 {
     test -z "$DEBUG_TRACE" || {
@@ -115,6 +121,94 @@ function ocp4_step_systemd_tmpfiles_create
     systemd-tmpfiles --create
 }
 
+function ocp4_helper_write_to_options_file
+{
+    printf '%q\n' "$1" >> "${OPTIONS_FILE}"
+}
+
+function ocp4_helper_has_principal_arg
+{
+    grep -sq '^--principal' "${OPTIONS_FILE}" "${DATA_OPTIONS_FILE}"
+}
+
+function ocp4_helper_has_ds_password_arg
+{
+    grep -sq '^--ds-password' "${OPTIONS_FILE}" "${DATA_OPTIONS_FILE}"
+}
+
+function ocp4_helper_process_password_admin_password
+{
+    # Freeipa admin password
+    if [ -n "${IPA_ADMIN_PASSWORD}" ]; then
+        if [ "${COMMAND}" == 'ipa-server-install' ] ; then
+            # printf '%q\n' "--admin-password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
+            ocp4_helper_write_to_options_file "--admin-password=${IPA_ADMIN_PASSWORD}"
+        elif [ "${COMMAND}" == "ipa-replica-install" ]; then
+            if ocp4_helper_has_principal_arg; then
+                # printf '%q\n' "--admin-password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
+                ocp4_helper_write_to_options_file "--admin-password=${IPA_ADMIN_PASSWORD}"
+            else
+                # printf '%q\n' "--password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
+                ocp4_helper_write_to_options_file "--password=${IPA_ADMIN_PASSWORD}"
+            fi
+        else
+            tasks_helper_msg_warning "Ignoring environment variable IPA_ADMIN_PASSWORD."
+        fi
+    fi
+}
+
+function ocp4_helper_process_password_dm_password
+{
+    # Directory manager password
+    if [ -n "${IPA_DM_PASSWORD}" ]; then
+        if [ "${COMMAND}" == 'ipa-server-install' ]; then
+            if ! ocp4_helper_has_ds_password_arg; then
+                # printf '%q\n' "--ds-password=${IPA_DM_PASSWORD}" >> "${OPTIONS_FILE}"
+                ocp4_helper_write_to_options_file "--ds-password=${IPA_DM_PASSWORD}"
+            fi
+        elif [ "${COMMAND}" == "ipa-replica-install" ]; then
+            tasks_helper_msg_info "IPA_DM_PASSWORD not used for replicas."
+        else
+            tasks_helper_msg_warning "Ignoring environment variable IPA_DM_PASSWORD."
+        fi
+    fi
+}
+
+function ocp4_helper_process_password
+{
+    ocp4_helper_process_password_admin_password
+    ocp4_helper_process_password_dm_password
+}
+
+function ocp4_step_process_first_boot
+{
+    if ! container_helper_exist_ca_cert ; then
+        if ! utils_is_a_file "${DATA}/ipa.csr" ; then
+            # Do not refresh $DATA in the second stage of the external CA setup
+            /usr/local/bin/populate-volume-from-template "${DATA}"
+            container_helper_create_machine_id
+        fi
+
+        ocp4_helper_process_password
+
+        if [ -n "$IPA_SERVER_INSTALL_OPTS" ] ; then
+            # FIXME Fix this shellcheck hint when refactoring this
+            #       function for unit tests
+            # shellcheck disable=SC2166
+            if [ "$COMMAND" == 'ipa-server-install' -o "$COMMAND" = 'ipa-replica-install' ] ; then
+                echo "$IPA_SERVER_INSTALL_OPTS" >> "$OPTIONS_FILE"
+            else
+                echo "Warning: ignoring environment variable IPA_SERVER_INSTALL_OPTS." >&2
+            fi
+        fi
+
+        if [ -n "${DEBUG}" ] ; then
+            echo "--debug" >> "${OPTIONS_FILE}"
+        fi
+    fi
+}
+
+
 OCP4_LIST_TASKS=()
 # +ocp4:begin-list
 OCP4_LIST_TASKS+=("ocp4_step_systemd_units_set_private_tmp_off")
@@ -130,6 +224,10 @@ tasks_helper_update_step \
 tasks_helper_update_step \
     "container_step_process_hostname" \
     "ocp4_step_process_hostname"
+
+tasks_helper_update_step \
+    "container_step_process_first_boot" \
+    "ocp4_step_process_first_boot"
 
 tasks_helper_add_after \
     "container_step_volume_update" \

--- a/init/ocp4.inc.sh
+++ b/init/ocp4.inc.sh
@@ -149,7 +149,7 @@ function ocp4_helper_process_password_admin_password
                 # Force 'Method 2: a privileged user’s credentials' for ipa-replica-install
                 # as described in the documentation at
                 # '19.4. Authorizing the installation of a replica on a system that is not enrolled into IdM'
-                tasks_helper_error "--principal required for container ipa-replica-install command"
+                tasks_helper_error "--principal option is required for container ipa-replica-install command"
             fi
         else
             tasks_helper_msg_warning "Ignoring environment variable IPA_ADMIN_PASSWORD."

--- a/init/ocp4.inc.sh
+++ b/init/ocp4.inc.sh
@@ -141,15 +141,15 @@ function ocp4_helper_process_password_admin_password
     # Freeipa admin password
     if [ -n "${IPA_ADMIN_PASSWORD}" ]; then
         if [ "${COMMAND}" == 'ipa-server-install' ] ; then
-            # printf '%q\n' "--admin-password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
             ocp4_helper_write_to_options_file "--admin-password=${IPA_ADMIN_PASSWORD}"
         elif [ "${COMMAND}" == "ipa-replica-install" ]; then
             if ocp4_helper_has_principal_arg; then
-                # printf '%q\n' "--admin-password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
                 ocp4_helper_write_to_options_file "--admin-password=${IPA_ADMIN_PASSWORD}"
             else
-                # printf '%q\n' "--password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
-                ocp4_helper_write_to_options_file "--password=${IPA_ADMIN_PASSWORD}"
+                # Force 'Method 2: a privileged user’s credentials' for ipa-replica-install
+                # as described in the documentation at
+                # '19.4. Authorizing the installation of a replica on a system that is not enrolled into IdM'
+                tasks_helper_error "--principal required for container ipa-replica-install command"
             fi
         else
             tasks_helper_msg_warning "Ignoring environment variable IPA_ADMIN_PASSWORD."
@@ -163,7 +163,6 @@ function ocp4_helper_process_password_dm_password
     if [ -n "${IPA_DM_PASSWORD}" ]; then
         if [ "${COMMAND}" == 'ipa-server-install' ]; then
             if ! ocp4_helper_has_ds_password_arg; then
-                # printf '%q\n' "--ds-password=${IPA_DM_PASSWORD}" >> "${OPTIONS_FILE}"
                 ocp4_helper_write_to_options_file "--ds-password=${IPA_DM_PASSWORD}"
             fi
         elif [ "${COMMAND}" == "ipa-replica-install" ]; then

--- a/init/ocp4.inc.sh
+++ b/init/ocp4.inc.sh
@@ -6,6 +6,19 @@ IPA_DM_PASSWORD="${IPA_DM_PASSWORD:-${PASSWORD}}"
 # Freeipa admin passowrd
 IPA_ADMIN_PASSWORD="${IPA_ADMIN_PASSWORD:-${PASSWORD}}"
 
+# TODO This could have changes when implementing
+#      the replicas for freeipa-operator repository.
+#
+# This need to get a OTP by:
+#
+# ```sh
+# kinit admin
+# ipa host-add replica.example.com --random
+# ```
+#
+# Reference: https://www.adelton.com/docs/idm/replicate-your-identity-management
+IPA_ENROLLMENT_OTP="${IPA_ENROLLMENT_OTP:-${PASSWORD}}"
+
 function ocp4_step_enable_traces
 {
     test -z "$DEBUG_TRACE" || {
@@ -141,16 +154,9 @@ function ocp4_helper_process_password_admin_password
     # Freeipa admin password
     if [ -n "${IPA_ADMIN_PASSWORD}" ]; then
         if [ "${COMMAND}" == 'ipa-server-install' ] ; then
-            # printf '%q\n' "--admin-password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
             ocp4_helper_write_to_options_file "--admin-password=${IPA_ADMIN_PASSWORD}"
         elif [ "${COMMAND}" == "ipa-replica-install" ]; then
-            if ocp4_helper_has_principal_arg; then
-                # printf '%q\n' "--admin-password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
-                ocp4_helper_write_to_options_file "--admin-password=${IPA_ADMIN_PASSWORD}"
-            else
-                # printf '%q\n' "--password=${IPA_ADMIN_PASSWORD}" >> "${OPTIONS_FILE}"
-                ocp4_helper_write_to_options_file "--password=${IPA_ADMIN_PASSWORD}"
-            fi
+            :
         else
             tasks_helper_msg_warning "Ignoring environment variable IPA_ADMIN_PASSWORD."
         fi
@@ -163,13 +169,28 @@ function ocp4_helper_process_password_dm_password
     if [ -n "${IPA_DM_PASSWORD}" ]; then
         if [ "${COMMAND}" == 'ipa-server-install' ]; then
             if ! ocp4_helper_has_ds_password_arg; then
-                # printf '%q\n' "--ds-password=${IPA_DM_PASSWORD}" >> "${OPTIONS_FILE}"
                 ocp4_helper_write_to_options_file "--ds-password=${IPA_DM_PASSWORD}"
             fi
         elif [ "${COMMAND}" == "ipa-replica-install" ]; then
-            tasks_helper_msg_info "IPA_DM_PASSWORD not used for replicas."
+            :
         else
             tasks_helper_msg_warning "Ignoring environment variable IPA_DM_PASSWORD."
+        fi
+    fi
+}
+
+function ocp4_helper_process_password_replica_password
+{
+    if [ -n "${IPA_ENROLLMENT_OTP}" ]; then
+        if [ "${COMMAND}" == 'ipa-replica-install' ] ; then
+            tasks_helper_msg_info "Using IPA_ENROLLMENT_OTP for replicas."
+            if ocp4_helper_has_principal_arg; then
+                ocp4_helper_write_to_options_file "--admin-password=${IPA_ENROLLMENT_OTP}"
+            else
+                ocp4_helper_write_to_options_file "--password=${IPA_ENROLLMENT_OTP}"
+            fi
+        else
+            tasks_helper_msg_warning "Ignoring environment variable IPA_ENROLLMENT_OTP."
         fi
     fi
 }
@@ -178,6 +199,7 @@ function ocp4_helper_process_password
 {
     ocp4_helper_process_password_admin_password
     ocp4_helper_process_password_dm_password
+    ocp4_helper_process_password_replica_password
 }
 
 function ocp4_step_process_first_boot

--- a/test/unit/ocp4.bats
+++ b/test/unit/ocp4.bats
@@ -45,21 +45,52 @@ function teardown
     unset IPA_ENROLLMENT_OTP
     export IPA_ENROLLMENT_OTP COMMAND
     mock stub "${_mocks[@]}"
-    run ocp4_helper_process_replica_password
+    run ocp4_helper_process_password_replica_password
     assert_success
     assert_output ""
     assert_mock "${_mocks[@]}"
     mock unstub "${_mocks[@]}"
 
-    # ipa-server-install
+    # Variable with no ipa-replica-install
     unset COMMAND
-    IPA_ENROLLMENT_OTP
+    IPA_ENROLLMENT_OTP="JustATest"
     export IPA_ENROLLMENT_OTP COMMAND
     mock stub "${_mocks[@]}"
     mock_tasks_helper_msg_warning 0 "Ignoring environment variable IPA_ENROLLMENT_OTP."
-    run ocp4_helper_process_replica_password
+    mock_tasks_helper_msg_warning output <<< "WARNING:Ignoring environment variable IPA_ENROLLMENT_OTP."
+    run ocp4_helper_process_password_replica_password
     assert_success
-    assert_output ""
+    assert_output "WARNING:Ignoring environment variable IPA_ENROLLMENT_OTP."
+    assert_mock "${_mocks[@]}"
+    mock unstub "${_mocks[@]}"
+
+    # ipa-replica-install and has_principal_arg
+    COMMAND="ipa-replica-install"
+    IPA_ENROLLMENT_OTP="JustATest"
+    export IPA_ENROLLMENT_OTP COMMAND
+    mock stub "${_mocks[@]}"
+    mock_tasks_helper_msg_info 0 "Using IPA_ENROLLMENT_OTP for replicas."
+    mock_tasks_helper_msg_info output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
+    mock_ocp4_helper_has_principal_arg 0
+    mock_ocp4_helper_write_to_options_file 0 "--admin-password=${IPA_ENROLLMENT_OTP}"
+    run ocp4_helper_process_password_replica_password
+    assert_success
+    assert_output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
+    assert_mock "${_mocks[@]}"
+    mock unstub "${_mocks[@]}"
+
+    # ipa-replica-install and not has_principal_arg
+    COMMAND="ipa-replica-install"
+    IPA_ENROLLMENT_OTP="JustATest"
+    export IPA_ENROLLMENT_OTP COMMAND
+    mock stub "${_mocks[@]}"
+    mock_tasks_helper_msg_info 0 "Using IPA_ENROLLMENT_OTP for replicas."
+    mock_tasks_helper_msg_info output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
+    mock_ocp4_helper_has_principal_arg 1
+    mock_ocp4_helper_write_to_options_file 0 "--password=${IPA_ENROLLMENT_OTP}"
+    run ocp4_helper_process_password_replica_password
+    assert_success
+    assert_output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
     assert_mock "${_mocks[@]}"
     mock unstub "${_mocks[@]}"
 }

--- a/test/unit/ocp4.bats
+++ b/test/unit/ocp4.bats
@@ -32,6 +32,39 @@ function teardown
 }
 
 
+@test "ocp4_helper_process_password_replica_password" {
+    source './init/ocp4.inc.sh'
+    local _mocks=()
+    _mocks+=("tasks_helper_msg_info")
+    _mocks+=("ocp4_helper_has_principal_arg")
+    _mocks+=("ocp4_helper_write_to_options_file")
+    _mocks+=("tasks_helper_msg_warning")
+
+    # No replica password
+    unset COMMAND
+    unset IPA_ENROLLMENT_OTP
+    export IPA_ENROLLMENT_OTP COMMAND
+    mock stub "${_mocks[@]}"
+    run ocp4_helper_process_replica_password
+    assert_success
+    assert_output ""
+    assert_mock "${_mocks[@]}"
+    mock unstub "${_mocks[@]}"
+
+    # ipa-server-install
+    unset COMMAND
+    IPA_ENROLLMENT_OTP
+    export IPA_ENROLLMENT_OTP COMMAND
+    mock stub "${_mocks[@]}"
+    mock_tasks_helper_msg_warning 0 "Ignoring environment variable IPA_ENROLLMENT_OTP."
+    run ocp4_helper_process_replica_password
+    assert_success
+    assert_output ""
+    assert_mock "${_mocks[@]}"
+    mock unstub "${_mocks[@]}"
+}
+
+
 @test "ocp4_helper_process_password_admin_password" {
     source './init/ocp4.inc.sh'
     local _mocks=()
@@ -152,11 +185,8 @@ function teardown
     COMMAND="ipa-replica-install"
     export IPA_DM_PASSWORD COMMAND
     mock stub "${_mocks[@]}"
-    mock_tasks_helper_msg_info 0 "IPA_DM_PASSWORD not used for replicas."
-    mock_tasks_helper_msg_info output <<< "INFO:IPA_DM_PASSWORD not used for replicas."
     run ocp4_helper_process_password_dm_password
     assert_success
-    assert_output <<< "INFO:IPA_DM_PASSWORD not used for replicas."
     assert_mock "${_mocks[@]}"
     mock unstub "${_mocks[@]}"
 

--- a/test/unit/ocp4.bats
+++ b/test/unit/ocp4.bats
@@ -38,6 +38,7 @@ function teardown
     _mocks+=("ocp4_helper_write_to_options_file")
     _mocks+=("ocp4_helper_has_principal_arg")
     _mocks+=("tasks_helper_msg_warning")
+    _mocks+=("tasks_helper_error")
 
     # No admin password
     unset COMMAND
@@ -80,10 +81,10 @@ function teardown
     COMMAND="ipa-replica-install"
     export IPA_ADMIN_PASSWORD COMMAND
     mock stub "${_mocks[@]}"
+    mock_tasks_helper_error 1 "--principal option is required for container ipa-replica-install command"
     mock_ocp4_helper_has_principal_arg 1
-    mock_ocp4_helper_write_to_options_file 0 "--password=${IPA_ADMIN_PASSWORD}"
     run ocp4_helper_process_password_admin_password
-    assert_success
+    assert_failure
     assert_output ""
     assert_mock "${_mocks[@]}"
     mock unstub "${_mocks[@]}"

--- a/test/unit/ocp4.bats
+++ b/test/unit/ocp4.bats
@@ -32,70 +32,6 @@ function teardown
 }
 
 
-@test "ocp4_helper_process_password_replica_password" {
-    source './init/ocp4.inc.sh'
-    local _mocks=()
-    _mocks+=("tasks_helper_msg_info")
-    _mocks+=("ocp4_helper_has_principal_arg")
-    _mocks+=("ocp4_helper_write_to_options_file")
-    _mocks+=("tasks_helper_msg_warning")
-
-    # No replica password
-    unset COMMAND
-    unset IPA_ENROLLMENT_OTP
-    export IPA_ENROLLMENT_OTP COMMAND
-    mock stub "${_mocks[@]}"
-    run ocp4_helper_process_password_replica_password
-    assert_success
-    assert_output ""
-    assert_mock "${_mocks[@]}"
-    mock unstub "${_mocks[@]}"
-
-    # Variable with no ipa-replica-install
-    unset COMMAND
-    IPA_ENROLLMENT_OTP="JustATest"
-    export IPA_ENROLLMENT_OTP COMMAND
-    mock stub "${_mocks[@]}"
-    mock_tasks_helper_msg_warning 0 "Ignoring environment variable IPA_ENROLLMENT_OTP."
-    mock_tasks_helper_msg_warning output <<< "WARNING:Ignoring environment variable IPA_ENROLLMENT_OTP."
-    run ocp4_helper_process_password_replica_password
-    assert_success
-    assert_output "WARNING:Ignoring environment variable IPA_ENROLLMENT_OTP."
-    assert_mock "${_mocks[@]}"
-    mock unstub "${_mocks[@]}"
-
-    # ipa-replica-install and has_principal_arg
-    COMMAND="ipa-replica-install"
-    IPA_ENROLLMENT_OTP="JustATest"
-    export IPA_ENROLLMENT_OTP COMMAND
-    mock stub "${_mocks[@]}"
-    mock_tasks_helper_msg_info 0 "Using IPA_ENROLLMENT_OTP for replicas."
-    mock_tasks_helper_msg_info output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
-    mock_ocp4_helper_has_principal_arg 0
-    mock_ocp4_helper_write_to_options_file 0 "--admin-password=${IPA_ENROLLMENT_OTP}"
-    run ocp4_helper_process_password_replica_password
-    assert_success
-    assert_output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
-    assert_mock "${_mocks[@]}"
-    mock unstub "${_mocks[@]}"
-
-    # ipa-replica-install and not has_principal_arg
-    COMMAND="ipa-replica-install"
-    IPA_ENROLLMENT_OTP="JustATest"
-    export IPA_ENROLLMENT_OTP COMMAND
-    mock stub "${_mocks[@]}"
-    mock_tasks_helper_msg_info 0 "Using IPA_ENROLLMENT_OTP for replicas."
-    mock_tasks_helper_msg_info output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
-    mock_ocp4_helper_has_principal_arg 1
-    mock_ocp4_helper_write_to_options_file 0 "--password=${IPA_ENROLLMENT_OTP}"
-    run ocp4_helper_process_password_replica_password
-    assert_success
-    assert_output <<< "INFO:Using IPA_ENROLLMENT_OTP for replicas."
-    assert_mock "${_mocks[@]}"
-    mock unstub "${_mocks[@]}"
-}
-
-
 @test "ocp4_helper_process_password_admin_password" {
     source './init/ocp4.inc.sh'
     local _mocks=()
@@ -216,8 +152,11 @@ function teardown
     COMMAND="ipa-replica-install"
     export IPA_DM_PASSWORD COMMAND
     mock stub "${_mocks[@]}"
+    mock_tasks_helper_msg_info 0 "IPA_DM_PASSWORD not used for replicas."
+    mock_tasks_helper_msg_info output <<< "INFO:IPA_DM_PASSWORD not used for replicas."
     run ocp4_helper_process_password_dm_password
     assert_success
+    assert_output <<< "INFO:IPA_DM_PASSWORD not used for replicas."
     assert_mock "${_mocks[@]}"
     mock unstub "${_mocks[@]}"
 


### PR DESCRIPTION
Split PASSWORD to allow to inject secrets for:
- IPA_DM_PASSWORD for the Directory Management password.
- IPA_ADMIN_PASSWORD for the admin password.

This will allow to specify them independently.