### PR TITLE
Build failure: manifest unknown

### DIFF
--- a/ci/config/env
+++ b/ci/config/env
@@ -1,4 +1,3 @@
 # Define the PARENT_IMG that is used for the container image
-# info of interest: https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/working_with_tags#deleting-a-tag
 # Digest for quay.io/freeipa/fedora-server:35
-PARENT_IMG=quay.io/freeipa/freeipa-server@sha256:87d9615924dd1ca02a99222a621759ba3d1d9c2206ff55919e75a50a93fdc3a1
+PARENT_IMG=quay.io/freeipa/freeipa-server:35

--- a/ci/config/env
+++ b/ci/config/env
@@ -1,3 +1,2 @@
 # Define the PARENT_IMG that is used for the container image
-# Digest for quay.io/freeipa/fedora-server:35
 PARENT_IMG=quay.io/freeipa/freeipa-server:35


### PR DESCRIPTION
Update PARENT_IMG to use a tag name

When the parent image is republished with a new
SHA, the old one stop being accesible (still not
deleted but not pullable), so it can not
be used for building a new image based on that.

Updating the the value for PARENT_IMG to reference
the parent image by tag name.
