### PR TITLE
implement workaround for systemd-tmpfiles failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN ( [ ! -e "/usr/local/share/ipa-container" ] \
          || rm -f /usr/local/sbin/init ) \
     && ln -svf /usr/local/share/ipa-container/init.sh /usr/local/sbin/init
 COPY ./init /usr/local/share/ipa-container
+COPY ./tmpfiles.conf /usr/lib/tmpfiles.d/00-ipa-container.conf
 
 ENTRYPOINT ["/usr/local/sbin/init"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ RUN ( [ ! -e "/usr/local/share/ipa-container" ] \
 COPY ./init /usr/local/share/ipa-container
 COPY ./tmpfiles.conf /usr/lib/tmpfiles.d/00-ipa-container.conf
 
+# Completely replace systemd-tmpfiles.  This is needed until FreeIPA
+# itself provides a way to select the tmpfiles implementation via
+# the 'ipapython.paths' facility.
+RUN mv /bin/systemd-tmpfiles /bin/systemd-tmpfiles.orig
+COPY ./init/tmpfiles.py /bin/systemd-tmpfiles
+
 ENTRYPOINT ["/usr/local/sbin/init"]
 
 ARG QUAY_EXPIRATION=2w

--- a/init/container.inc.sh
+++ b/init/container.inc.sh
@@ -70,7 +70,13 @@ function container_helper_invoke_populate_volume_from_template
 {
     local directory="$1"
     [ "${directory}" != "" ] || return 1
-    /usr/local/bin/populate-volume-from-template "${directory}"
+    # Modify the populate-volume-from-template program to tolerate
+    # chmod/chown failure.  We do this "inline" so that we do not
+    # write the root fs (which may be read-only).
+    sed \
+        's/\(\s*\(chown\|chmod\).*\)/\1 || ( echo "Failed to \2 $VOLUME" ; ls -ld "$VOLUME" )/' \
+        /usr/local/bin/populate-volume-from-template \
+        | /bin/sh -s "${directory}"
 }
 
 function container_step_populate_tmp

--- a/init/container.inc.sh
+++ b/init/container.inc.sh
@@ -426,8 +426,10 @@ function container_step_volume_update
             # shellcheck disable=SC2162,SC2002
             cat /etc/volume-data-list | while read i ; do
                 if [ -e "${DATA_TEMPLATE}$i" ] && [ -e "$DATA$i" ] ; then
-                    chown "--reference=${DATA_TEMPLATE}$i" "${DATA}$i"
-                    chmod "--reference=${DATA_TEMPLATE}$i" "${DATA}$i"
+                    chown "--reference=${DATA_TEMPLATE}$i" "${DATA}$i" \
+                        || ( echo "Failed to chown $VOLUME" ; ls -ld "$VOLUME" )
+                    chmod "--reference=${DATA_TEMPLATE}$i" "${DATA}$i" \
+                        || ( echo "Failed to chmod $VOLUME" ; ls -ld "$VOLUME" )
                 fi
             done
             SYSTEMD_OPTS=--unit=ipa-server-upgrade.service

--- a/init/container.inc.sh
+++ b/init/container.inc.sh
@@ -73,7 +73,7 @@ function container_helper_invoke_populate_volume_from_template
     /usr/local/bin/populate-volume-from-template "${directory}"
 }
 
-function container_step_populate_volume_from_template
+function container_step_populate_tmp
 {
     container_helper_invoke_populate_volume_from_template "/tmp"
 }
@@ -508,7 +508,7 @@ CONTAINER_LIST_TASKS+=("container_step_enable_traces")
 CONTAINER_LIST_TASKS+=("container_step_set_workdir_to_root")
 CONTAINER_LIST_TASKS+=("container_step_exec_whitelist_commands")
 CONTAINER_LIST_TASKS+=("container_step_clean_directories")
-CONTAINER_LIST_TASKS+=("container_step_populate_volume_from_template")
+CONTAINER_LIST_TASKS+=("container_step_populate_tmp")
 CONTAINER_LIST_TASKS+=("container_step_create_directories")
 CONTAINER_LIST_TASKS+=("container_step_link_journal")
 CONTAINER_LIST_TASKS+=("container_step_do_check_terminate_await")

--- a/init/ocp4.inc.sh
+++ b/init/ocp4.inc.sh
@@ -118,7 +118,7 @@ function ocp4_step_process_hostname
 
 function ocp4_step_systemd_tmpfiles_create
 {
-    systemd-tmpfiles --create
+    /usr/local/share/ipa-container/tmpfiles.py --create
 }
 
 function ocp4_helper_write_to_options_file

--- a/init/tmpfiles.py
+++ b/init/tmpfiles.py
@@ -1,0 +1,651 @@
+#!/bin/python3
+
+"""
+
+Script that processes systemd-tmpfiles config files, approximately
+in the manner described by `tmpfiles.d(5)`.
+
+Only creates files/dirs/links, chowns, chmods, sets attributes and
+ACLs.  Does not implement cleanup and removal.
+
+`!` (indicating post-boot unsafety) is ignored, because this script
+is only intended to be used at container startup.
+
+ONLY files in `/usr/lib/tmpfiles.d` are read - not the other
+directories.  Does not perform any conflict resolution (where the
+same target file is mentioned by multiple config files).
+
+"""
+
+import collections
+import glob
+import grp
+import itertools
+import operator
+import os
+import pwd
+import shutil
+import stat
+import subprocess
+import sys
+
+TMPFILES_DIR = "/usr/lib/tmpfiles.d"
+FACTORY_DIR = "/usr/share/factory"
+
+
+def list_tmpfiles_configs():
+    """
+    Return sorted list of absolute paths to tmpfiles configs.
+    """
+    return sorted(
+        os.path.join(TMPFILES_DIR, f)
+        for f in os.listdir(TMPFILES_DIR)
+        if f.endswith(".conf")
+    )
+
+
+def read_tmpfiles_config(path):
+    """
+    Read the tmpfiles config.  Return a `list` of groups of
+    `(path,list_of_actions)` tuples, with paths in lexicographic
+    order.  Therefore, prefix/parent paths are always listed before
+    suffix/child paths.
+
+    """
+    with open(path) as f:
+        lines = f.readlines()
+    actions = (
+        parse_action(line.strip())
+        for line in lines
+        if len(line.strip()) > 0 and not line.startswith("#")
+    )
+
+    # putting things in order.
+    #
+    # pass 1: sort all actions by path.
+    #         output is iterable of (path, action)
+    #
+    actions = sorted(actions, key=operator.itemgetter(0))
+
+    # pass 2: group actions by path.
+    #         output is iterable of (path, [(path, action)])
+    actions = itertools.groupby(actions, key=operator.itemgetter(0))
+
+    # pass 2.1: discard redundant path, dissolve nested tuple.
+    #           output is iterable of (path, [action])
+    actions = ((k, map(operator.itemgetter(1), v)) for k, v in actions)
+
+    # pass 3: sort actions for each path
+    ACTION_ORDER = list(ACTION_MAP.values())
+
+    def f(action):
+        return ACTION_ORDER.index(type(action))
+
+    actions = ((path, sorted(l, key=f)) for path, l in actions)
+
+    # finally, return a list (makes debugging easier)
+    return list(actions)
+
+
+def parse_action(line):
+    """
+    Parse a line, returning a `(path,action)` pair or raising
+    ValueError on parse failure.  This function should NOT be
+    applied to empty lines or comments.
+    """
+    fields = line.split(maxsplit=6)
+    fields += [None] * (7 - len(fields))  # extend to required length
+    typ, path, mode, user, group, age, arg = fields
+
+    boot_only = "!" in typ
+    ignore_error = "-" in typ  # TODO implement
+    remove_mismatched = "=" in typ  # TODO implement
+    typ = typ.strip("!-=")
+
+    action = ACTION_MAP[typ](boot_only, mode, user, group, age, arg)
+    return (path, action)
+
+
+def main(dry_run):
+    config_files = list_tmpfiles_configs()
+    for config_file in config_files:
+        for path, actions in read_tmpfiles_config(config_file):
+            print(f">>> {path}")
+            for action in actions:
+                if dry_run:
+                    print(action)
+                else:
+                    action.apply(path)
+
+
+def _parse_mode(s):
+    if s is None:
+        return None
+
+    mask = False
+    if s.startswith("~"):
+        mask = True
+        s = s[1:]
+
+    return (mask, int(s, base=8))
+
+
+def _parse_user(s):
+    if s is None:
+        return None
+    try:
+        return int(s)
+    except ValueError:
+        return pwd.getpwnam(s)[2]
+
+
+def _parse_group(s):
+    if s is None:
+        return None
+    try:
+        return int(s)
+    except ValueError:
+        return grp.getgrnam(s)[2]
+
+
+def _parse_attrs(s):
+    if not s:  # None or empty string
+        raise ValueError("file attributes cannot be empty")
+    if s[0] not in "+-=":
+        s = "+" + s  # default operation is '+'
+
+    # TODO more complete checks?  For now just take it as-is.
+    return s
+
+
+def _parse_acls(s):
+    if not s:  # None or empty string
+        raise ValueError("file ACLs cannot be empty")
+
+    # TODO more checks?
+    return s
+
+
+def _parse_major_minor(s):
+    if s is None:
+        raise ValueError("major:minor cannot be empty")
+
+    parts = s.split(":")
+    if len(parts) != 2:
+        raise ValueError("major:minor must have 2 parts")
+
+    try:
+        major = int(parts[0])
+        minor = int(parts[1])
+    except ValueError:
+        raise ValueError("major:minor must be integers")
+
+    return (major, minor)
+
+
+def _run_process(desc, args):
+    try:
+        subprocess.check_call(args)
+    except FileNotFoundError:
+        if len(args) < 1:
+            prog = "<undefined>"
+        else:
+            prog = args[0]
+        print(f"failed to {desc}: {prog!r} program not found")
+    except subprocess.CalledProcessError as e:
+        print(f"failed to {desc}: {e}")
+
+
+class Action:
+    # function to parse/massage argument value
+    # If should raise ValueError for invalid input.
+    arg_function = staticmethod(lambda x: x)
+
+    def __init__(self, bootonly, mode, user, group, age, arg):
+        self.bootonly = bootonly
+        self._set("mode", mode, function=_parse_mode)
+        self._set("user", user, function=_parse_user)
+        self._set("group", group, function=_parse_group)
+        self._set("age", age, function=lambda TODO: TODO)
+        self._set("arg", arg, function=self.arg_function)
+
+    def _set(self, k, v, function=lambda x: x):
+        if v == "-":
+            v = None
+        setattr(self, k, function(v))
+
+    def describe(self, path):
+        """Describe the action."""
+        raise NotImplementedError
+
+    def apply(self, path):
+        """Apply the action."""
+        self.apply_one(path)
+
+    def apply_one(self, path):
+        """
+        Apply the action on a single path.
+
+        This function may be called an arbitrary number of times
+        (including zero) for glob-based actions.
+
+        """
+        raise NotImplementedError
+
+    def _chmod(self, path):
+        """Set the file mode.  Caller must ensure file exists."""
+        if self.mode is None:
+            mask = False
+            if os.path.islink(path) or not os.path.isdir(path):
+                mode = 0o644  # is a file or symbolic link
+            else:
+                mode = 0o755  # is a dir
+        else:
+            mask, mode = self.mode
+
+        if mask:
+            r = os.lstat(path).st_mode  # stat file
+
+            # existing mode masks new mode
+            mode &= stat.S_IMODE(r)
+
+            # unset sticky/SUID/SGID unless directory
+            if not stat.S_ISDIR(r):
+                mode &= ~(stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)
+
+        try:
+            os.chmod(path, mode, follow_symlinks=False)
+        except:
+            print(f"failed to chmod {path!r}")
+
+    def _chown(self, path):
+        """Set the file ownership.  Caller must ensure file exists."""
+        user = self.user
+        if user is None:
+            user = -1
+        group = self.group
+        if group is None:
+            group = -1
+        if user >= 0 or group >= 0:
+            try:
+                os.chown(path, user, group, follow_symlinks=False)
+            except:
+                print(f"failed to chmod {path!r}")
+
+
+class GlobAction(Action):
+    """Action that takes a glob rather than a path."""
+
+    def apply(self, pattern):
+        for path in glob.glob(pattern):
+            self.apply_one(path)
+
+
+class FileCreate(Action):
+    """f - create file with optional content"""
+
+    def apply_one(self, path):
+        if not os.path.lexists(path):
+            with open(path, "w") as f:
+                f.write(self.arg if self.arg is not None else "")
+        self._chmod(path)
+        self._chown(path)
+
+
+class FileCreateOrTruncate(Action):
+    """f+ - create or truncate file, with optional content"""
+
+    def apply_one(self, path):
+        with open(path, "w") as f:
+            f.write(self.arg if self.arg is not None else "")
+        self._chmod(path)
+        self._chown(path)
+
+
+class FileWrite(GlobAction):
+    """w - write to file"""
+
+    # TODO interpret C-style blackslashes in argument.  Also for
+    # other actions (f, f+, w+, ...)
+    def apply_one(self, path):
+        with open(path, "w") as f:
+            f.write(self.arg if self.arg is not None else "")
+        self._chmod(path)
+        self._chown(path)
+
+
+class FileAppend(GlobAction):
+    """w+ - append to file"""
+
+    def apply_one(self, path):
+        with open(path, "a") as f:
+            f.write(self.arg if self.arg is not None else "")
+        self._chmod(path)
+        self._chown(path)
+
+
+class DirCreateAndCleanup(Action):
+    """d - create and cleanup directory"""
+
+    def apply_one(self, path):
+        if not os.path.lexists(path):
+            os.makedirs(path)
+            self._chmod(path)
+            self._chown(path)
+
+
+class DirCreateAndRemove(DirCreateAndCleanup):
+    """D - create and remove directory"""
+
+    # No additional behaviour, until --remove gets implemented
+
+
+class DirCleanup(GlobAction):
+    """e - create and remove directory"""
+
+    def apply_one(self, path):
+        if os.path.isdir(path):
+            self._chmod(path)
+            self._chown(path)
+
+
+class SubvolumeCreate_v(DirCreateAndCleanup):
+    """v - create subvolume or directory"""
+
+    # ignore subvolume behaviour
+
+
+class SubvolumeCreate_q(DirCreateAndCleanup):
+    """q - create subvolume or directory"""
+
+    # ignore subvolume behaviour
+
+
+class SubvolumeCreate_Q(DirCreateAndCleanup):
+    """Q - create subvolume or directory"""
+
+    # ignore subvolume behaviour
+
+
+# TODO p, p+
+
+
+class SymlinkCreate(Action):
+    """L - create symlink"""
+
+    def apply_one(self, path):
+        if not os.path.exists(path):
+            if self.arg is None:
+                # TODO link to /usr/share/factory/FILE
+                # (see tmpfiles.d(5) for details)
+                raise RuntimeError("symlink target not specified")
+            os.symlink(self.arg, path)
+
+
+class SymlinkRecreate(SymlinkCreate):
+    """L+ - [re]create symlink"""
+
+    def apply_one(self, path):
+        if os.path.exists(path):
+            if not os.path.islink(path) and os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.unlink(path)
+        super().apply(path)
+
+
+class CreateCharDev(Action):
+    """c - create character device node"""
+
+    arg_function = staticmethod(_parse_major_minor)
+
+    def apply_one(self, path):
+        major, minor = self.args
+        if not os.path.lexists():
+            _run_process(
+                f"create character device at {path}",
+                ["mknod", path, c, major, minor],
+            )
+
+
+# TODO c+ b b+ (char and block devices)
+
+
+class Copy(Action):
+    """C - copy file"""
+
+    def apply_one(self, path):
+        src = self.arg
+        if src is None:
+            src = os.path.join(FACTORY_DIR, os.path.relpath(path, start="/"))
+
+        # if path is a symlink, resolve it
+        if os.path.islink(path):
+            path = os.path.join(os.path.dirname(path), os.readlink(path))
+
+        # ensure intermediate directories exist
+        if not os.path.isdir(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+
+        if os.path.islink(src) or not os.path.isdir(src):
+            if not os.path.exists(path):
+                shutil.copy(src, path, follow_symlinks=False)
+        else:  # src is a directory
+            if (
+                os.path.isdir(path)
+                and not os.path.islink(path)
+                and len(os.listdir(path)) <= 0
+            ):
+                # dst is a empty dir.  remove it (it will be recreated)
+                os.rmdir(path)
+            if not os.path.exists(path):
+                shutil.copytree(src, path, symlinks=True)
+
+
+class IgnoreRecursive(GlobAction):
+    """x - ignore path or glob recursively"""
+
+    def apply_one(_self, _path):
+        pass  # nothing to due; only applies to cleanup
+
+
+class Ignore(GlobAction):
+    """X - ignore path or glob"""
+
+    def apply_one(_self, _path):
+        pass  # nothing to due; only applies to cleanup
+
+
+class Remove(GlobAction):
+    """r - remove empty dir"""
+
+    def apply_one(self, path):
+        if os.path.islink(path) or not os.path.isdir(path):
+            os.unlink(path)
+        elif len(os.listdir(path)) <= 0:
+            os.rmdir(path)
+
+
+class RemoveRecursive(GlobAction):
+    """R - recursive delete"""
+
+    def apply_one(self, path):
+        if os.path.islink(path) or not os.path.isdir(path):
+            os.unlink(path)
+        else:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+# TODO t T
+
+
+class ModeAdjust(GlobAction):
+    """z - adjust mode/user/group"""
+
+    def apply_one(self, path):
+        if os.path.lexists(path):
+            self._chmod(path)
+            self._chown(path)
+            # TODO restore SELinux context
+
+
+class ModeAdjustRecursive(GlobAction):
+    """Z - adjust mode/user/group recursively"""
+
+    def apply_one(self, path):
+        if os.path.islink(path) or not os.path.isdir(path):
+            # link or file
+            self._chmod(path)
+            self._chown(path)
+            # TODO restore SELinux context
+        else:  # directory
+            for dirname, dirs, files in os.walk(path):
+                for filename in dirs + files:
+                    node = os.path.join(dirname, filename)
+                    self._chmod(node)
+                    self._chown(node)
+                    # TODO restore SELinux context
+
+
+class AttrsSet(GlobAction):
+    """h - set file attributes"""
+
+    arg_function = staticmethod(_parse_attrs)
+    chattr_args = []
+
+    def apply_one(self, path):
+        _run_process(
+            f"change attributes of {path}",
+            ["chattr"] + self.chattr_args + [self.arg, path],
+        )
+
+
+class AttrsSetRecursive(AttrsSet):
+    """H - set file attributes recursively"""
+
+    chattr_args = ["-R"]
+
+
+class ACLsSet(GlobAction):
+    """a - set POSIX ACLs"""
+
+    arg_function = staticmethod(_parse_acls)
+
+    def apply_one(self, path):
+        _run_process(
+            f"clear ACLs of {path}",
+            ["setfacl", "--remove-all", "--", path],
+        )
+        _run_process(
+            f"set ACLs of {path}",
+            ["setfacl", "--modify", self.arg, "--", path],
+        )
+
+
+class ACLsAppend(GlobAction):
+    """a+ - append POSIX ACLs"""
+
+    arg_function = staticmethod(_parse_acls)
+
+    def apply_one(self, path):
+        _run_process(
+            f"set ACLs of {path}",
+            ["setfacl", "--modify", self.arg, "--", path],
+        )
+
+
+class ACLsSetRecursive(GlobAction):
+    """A - set POSIX ACLs recursively"""
+
+    arg_function = staticmethod(_parse_acls)
+
+    def apply_one(self, path):
+        _run_process(
+            f"clear ACLs (recursively) of {path}",
+            ["setfacl", "--recursive", "--remove-all", "--", path],
+        )
+        _run_process(
+            f"set ACLs (recursively) of {path}",
+            [
+                "setfacl",
+                "--recursive",
+                "--physical",
+                "--modify",
+                self.arg,
+                "--",
+                path,
+            ],
+        )
+
+
+class ACLsAppendRecursive(GlobAction):
+    """A+ - append POSIX ACLs recursively"""
+
+    arg_function = staticmethod(_parse_acls)
+
+    def apply_one(self, path):
+        _run_process(
+            f"set ACLs (recursively) of {path}",
+            [
+                "setfacl",
+                "--recursive",
+                "--physical",
+                "--modify",
+                self.arg,
+                "--",
+                path,
+            ],
+        )
+
+
+"""
+Map of action type string to class.
+
+This is an OrderedDict so that the insertion order determines the
+order in which actions on the same path shall be performed.  An
+example of why this is needed is that a file must be created
+before you can set attributes, ACLs, etc.
+
+The order is the order in which they appear in tmpfiles.d(5).  The
+order seems reasonable, although I'm not sure whether it is the
+order that systemd-tmpfiles actually uses.
+
+TODO: % specifiers (at least %b and %m are required)
+
+"""
+ACTION_MAP = collections.OrderedDict(
+    [
+        ("f", FileCreate),
+        ("f+", FileCreateOrTruncate),
+        ("F", FileCreateOrTruncate),  # deprecated alias
+        ("w", FileWrite),
+        ("w+", FileAppend),
+        ("d", DirCreateAndCleanup),
+        ("D", DirCreateAndRemove),
+        ("e", DirCleanup),
+        ("v", SubvolumeCreate_v),
+        ("q", SubvolumeCreate_q),
+        ("Q", SubvolumeCreate_Q),
+        ("L", SymlinkCreate),
+        ("L+", SymlinkRecreate),
+        ("c", CreateCharDev),
+        ("C", Copy),
+        ("x", IgnoreRecursive),
+        ("X", Ignore),
+        ("r", Remove),
+        ("R", RemoveRecursive),
+        ("z", ModeAdjust),
+        ("m", ModeAdjust),  # deprecated alias
+        ("Z", ModeAdjustRecursive),
+        ("h", AttrsSet),
+        ("H", AttrsSetRecursive),
+        ("a", ACLsSet),
+        ("a+", ACLsAppend),
+        ("A", ACLsSetRecursive),
+        ("A+", ACLsAppendRecursive),
+    ]
+)
+
+
+if __name__ == "__main__":
+    main(dry_run="--dry-run" in sys.argv)

--- a/init/tmpfiles.py
+++ b/init/tmpfiles.py
@@ -362,7 +362,7 @@ class DirCreateAndCleanup(Action):
     def apply_one(self, path):
         if not os.path.lexists(path):
             os.makedirs(path)
-            self._chown_and_chmod(path)
+        self._chown_and_chmod(path)
 
 
 class DirCreateAndRemove(DirCreateAndCleanup):

--- a/test/unit/container.bats
+++ b/test/unit/container.bats
@@ -94,14 +94,14 @@ load '../libs/bats-mock/load'
 }
 
 
-@test "container_step_populate_volume_from_template" {
+@test "container_step_populate_tmp" {
     source './init/utils.inc.sh'
     source './init/tasks.inc.sh'
     source './init/container.inc.sh'
 
     mock stub container_helper_invoke_populate_volume_from_template
     mock_container_helper_invoke_populate_volume_from_template 0 "/tmp"
-    run container_step_populate_volume_from_template
+    run container_step_populate_tmp
     assert_success
     assert_mock container_helper_invoke_populate_volume_from_template
     mock unstub container_helper_invoke_populate_volume_from_template

--- a/test/unit/ocp4.bats
+++ b/test/unit/ocp4.bats
@@ -193,18 +193,6 @@ function teardown
 }
 
 
-@test "ocp4_step_systemd_tmpfiles_create" {
-    source './init/ocp4.inc.sh'
-
-    mock stub systemd-tmpfiles
-    mock_systemd-tmpfiles 0 --create
-    run ocp4_step_systemd_tmpfiles_create
-    assert_success
-    assert_mock systemd-tmpfiles
-    mock unstub systemd-tmpfiles
-}
-
-
 @test "ocp4_step_enable_traces" {
 
     source './init/ocp4.inc.sh'

--- a/tmpfiles.conf
+++ b/tmpfiles.conf
@@ -1,0 +1,2 @@
+d /data/var/lib/systemd
+d /data/var/lib/tpm2-tss


### PR DESCRIPTION
Note: please rebase-merge, not squash-merge.

```
45fc7b2 (Fraser Tweedale, 2 hours ago)
   replace systemd-tmpfiles with tmpfiles.py

   Overwrite /bin/systemd-tmpfiles with our tmpfiles.py program.  This is
   needed because the FreeIPA installer explicitly invokes systemd-tmpfiles in
   some places.  Those invocations fail, which causes installation to fail.

   This is expected to be a temporary change until FreeBSD provides a way to
   select an alternative tmpfiles implementation via the ipapython.paths
   facility.

6c62d48 (Fraser Tweedale, 2 hours ago)
   tmpfiles.py: implement --prefix

   Implement the --prefix option for restricting the set of paths that are
   acted upon.

   Also add the --create, --remove and --clean options to conform to the
   interface of systemd-tmpfiles(8).  --remove and --clean are not 
   implemented, but the CLI options are recognised.

43e5b90 (Fraser Tweedale, 5 hours ago)
   tmpfiles.py: handle missing 'chattr' program

   If chattr(1) doesn't exist on the system (container), emit a notice instead
   of crashing the program.

e9c2f4d (Fraser Tweedale, 26 hours ago)
   use tmpfiles.py instead of systemd-tmpfiles

   Convert to tmpfiles.py instead of systemd-tmpfiles for initialising the
   tmpfiles.  This avoids the path processing problems encountered by
   systemd-tmpfiles due to emptyDir mounts being owned by unmapped users when
   running the workload in an isolated user namespace.

   Remove the unit test, because it appears the bats-mock framework cannot
   handle mocking a program specified by full path (i.e. containing slashes).

f048b7b (Fraser Tweedale, 5 days ago)
   add tmpfiles.py

209ce3b (Fraser Tweedale, 2 days ago)
   add tmpfiles config

   The IPA container needs a few extra tmpfiles directives related to the
   /data volume - mainly to solve some dangling symlinks.  Add a dedicated
   tmpfiles config file that runs early.

4554475 (Fraser Tweedale, 2 weeks ago)
   tolerate chmod/chown failure when populating templates

   In some container environments it is not possible to chown and chmod some
   volumes.  In particular, Kubernetes/OpenShift emptyDir mounts for /tmp,
   /run, etc, when running in user namespaces, will be owned by root on the
   host, which is unmapped in the user namespace.

   Tolerate the failure of chmod/chown operation.  We do this by
   "modifying" the /usr/local/bin/populate-volume-from-template program. 
   Rather than writing a modified version of the program, we do it via sed and
   pipe the result to the /bin/sh for execution.

   The result of the sed program is to transform the lines:

       chown --reference="$VOLUME-template" "$VOLUME"
      chmod --reference="$VOLUME-template" "$VOLUME"

   into (folded for readability):

       chown --reference="$VOLUME-template" "$VOLUME" \
          || ( echo "Failed to chown $VOLUME" ; ls -ld "$VOLUME" )
      chmod --reference="$VOLUME-template" "$VOLUME" \
          || ( echo "Failed to chmod $VOLUME" ; ls -ld "$VOLUME" )

da5e879 (Fraser Tweedale, 2 weeks ago)
   rename "populate tmp" step

   Use a more accurate name for the step that populates "tmp".  In particular,
   the goal is to disambiguate it from the helper routine that actually
   invokes /usr/local/bin/populate-volume-from-template.

77dd638 (Fraser Tweedale, 2 weeks ago)
   container-step-volume-update: tolerate chown/chmod failure

   In some container environments it is not possible to chown and chmod 
   particular volumes.  In particular, emptyDir mounts for /tmp, /run etc on
   OpenShift, when running in user namespaces, will be owned by root on the
   host, which is unmapped in the user namespace.

   Tolerate the failure of the chmod/chown operations.  Instead, merely emit a
   notice when it fails.
```