### PR TITLE
Lookup tmpfiles conf files in /etc/ and /run

### DIFF
--- a/init/tmpfiles.py
+++ b/init/tmpfiles.py
@@ -52,13 +52,15 @@ def list_tmpfiles_configs():
             candidates = os.listdir(confdir)
         except NotADirectoryError:
             continue
-        for conffile in sorted(candidates):
+        for conffile in candidates:
             if not conffile.endswith(".conf"):
                 continue
             if conffile in seen:
                 continue
             seen.add(conffile)
             conffiles.append(os.path.join(confdir, conffile))
+    # sort by file name, no matter which directory the file resides in.
+    conffiles.sort(key=os.path.basename)
     return conffiles
 
 

--- a/init/tmpfiles.py
+++ b/init/tmpfiles.py
@@ -50,7 +50,7 @@ def list_tmpfiles_configs():
     for confdir in TMPFILES_DIRS:
         try:
             candidates = os.listdir(confdir)
-        except NotADirectoryError:
+        except (NotADirectoryError, FileNotFoundError):
             continue
         for conffile in candidates:
             if not conffile.endswith(".conf"):


### PR DESCRIPTION
Implement logic to load config files from /etc and /run with overrides.

Signed-off-by: Christian Heimes <cheimes@redhat.com>