### PR TITLE
remove "systemd hardening efforts" from dirsrv service (fixes #42)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,20 @@ ARG PARENT_IMG=quay.io/freeipa/freeipa-server:fedora-35
 # hadolint ignore=DL3006
 FROM ${PARENT_IMG}
 
+# dirsrv@.service must not depend on special systemd feature which won't work in OKD/OpenShift
+RUN sed -i 's/^ProtectSystem=full/# ProtectSystem=full/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ReadWritePaths=/# ReadWritePaths=/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectHome=true/# ProtectHome=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^PrivateDevices=true/# PrivateDevices=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectHostname=true/# ProtectHostname=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectClock=true/# ProtectClock=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectKernelTunables=true/# ProtectKernelTunables=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectKernelModules=true/# ProtectKernelModules=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectKernelLogs=true/# ProtectKernelLogs=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectKernelLogs=true/# ProtectKernelLogs=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^ProtectControlGroups=true/# ProtectControlGroups=true/g' /usr/lib/systemd/system/dirsrv@.service
+RUN sed -i 's/^RestrictRealtime=true/# RestrictRealtime=true/g' /usr/lib/systemd/system/dirsrv@.service
+
 # Just copy the ocp4 include shell file and parse the include list to 
 # add it at the end
 # COPY ./init/ocp4.inc.sh /usr/local/share/ipa-container/ocp4.inc.sh


### PR DESCRIPTION
Dockerfile patches /usr/lib/systemd/system/dirsrv@.service
This service must not depend on special systemd features which won't work in OKD/OpenShift with the current free-ipa scc

Simple workaround to "fix" issue #42 and get [FreeIPA 4.10.0 from Fedora Rawhide](https://hub.docker.com/layers/freeipa-server/freeipa/freeipa-server/fedora-rawhide-4.10.0/images/sha256-639242245443f45bc9c658b8b6cba647ab5f5c25390b491256fdaeb538447178?context=explore) running in OKD/OpenShift.